### PR TITLE
event_reinit after fork

### DIFF
--- a/server.c
+++ b/server.c
@@ -213,6 +213,11 @@ server_start(struct server *s) {
 
 	if(s->cfg->daemonize) {
 		server_daemonize();
+
+		/* sometimes event mech gets lost on fork */
+		if(event_reinit(s->base) != 0) {
+			fprintf(stderr, "Error: event_reinit failed after fork");
+		}
 	}
 
 	/* ignore sigpipe */


### PR DESCRIPTION
Hi Nicolas,
I edited server.c to reinit events after the transition to a daemon because webdis would abruptly exit on OS X when daemonize was set to true in the conf. Adding this seems to fix things, so I hope that you can find this to be useful.

Cheers
