### PR TITLE
Continue trying to reconnect

### DIFF
--- a/pool.c
+++ b/pool.c
@@ -126,6 +126,7 @@ pool_connect(struct pool *p, int attach) {
 		*/
 		/* fprintf(stderr, "Error: %s\n", ac->errstr); */
 		redisAsyncFree(ac);
+		pool_schedule_reconnect(p);
 		return NULL;
 	}
 


### PR DESCRIPTION
Current code doesn't continue trying to reconnect after an error occurs. This pull request has a one line change that continues trying to reconnect even on failure.
