### PR TITLE
Half Connection

### DIFF
--- a/server.c
+++ b/server.c
@@ -179,6 +179,10 @@ server_start(struct server *s) {
 	if(s->fd < 0) {
 		return -1;
 	}
+	
+	/*set keepalive socket option to do with half connection*/
+        int keep_alive = 1;
+        setsockopt(s->fd , SOL_SOCKET, SO_KEEPALIVE, (void*)&keep_alive, sizeof(keep_alive));
 
 	/* start http server */
 	event_set(&s->ev, s->fd, EV_READ | EV_PERSIST, server_can_accept, s);


### PR DESCRIPTION
when client crash or network broken,webdis also keep the connection established for 20 hours.According TCPIP Protocal, webdis should send KeepAlive probe package to detect this,but tcpdump didn't capture this package.

webdis server tcpdump
linux-191:~/nicolasff-webdis-8a8ab84 # tcpdump -i eth0 host 10.0.64.10 and port 7379
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 96 bytes
09:10:30.161126 IP 10.0.64.10.40770 > linux-191.site.7379: S 272338310:272338310(0) win 5840 
09:10:30.161155 IP linux-191.site.7379 > 10.0.64.10.40770: S 652998709:652998709(0) ack 272338311 win 5792 
09:10:30.161495 IP 10.0.64.10.40770 > linux-191.site.7379: . ack 1 win 46 
09:10:30.200643 IP 10.0.64.10.40770 > linux-191.site.7379: P 1:257(256) ack 1 win 46 
09:10:30.200655 IP linux-191.site.7379 > 10.0.64.10.40770: . ack 257 win 54 
09:10:30.338561 IP linux-191.site.7379 > 10.0.64.10.40770: P 1:267(266) ack 257 win 54 
09:10:30.338976 IP 10.0.64.10.40770 > linux-191.site.7379: . ack 267 win 54

11:15:30.267179 IP 10.0.64.10.40770 > linux-191.site.7379: P 257:513(256) ack 267 win 54 
11:15:30.267209 IP linux-191.site.7379 > 10.0.64.10.40770: . ack 513 win 62 
11:15:30.392543 IP linux-191.site.7379 > 10.0.64.10.40770: P 267:533(266) ack 513 win 62 
11:15:30.392908 IP 10.0.64.10.40770 > linux-191.site.7379: . ack 533 win 63 
13:20:30.363517 IP 10.0.64.10.40770 > linux-191.site.7379: P 513:769(256) ack 533 win 63 
13:20:30.363541 IP linux-191.site.7379 > 10.0.64.10.40770: . ack 769 win 71 
13:20:30.497825 IP linux-191.site.7379 > 10.0.64.10.40770: P 533:799(266) ack 769 win 71 
13:20:30.498587 IP 10.0.64.10.40770 > linux-191.site.7379: . ack 799 win 71

at 14:00 network broken.
