### PR TITLE
Websocket SUBSCRIBE KeepAlive fixed

### DIFF
--- a/websocket.c
+++ b/websocket.c
@@ -364,6 +364,10 @@ ws_reply(struct cmd *cmd, const char *p, size_t sz) {
 
 	/* send WS frame */
 	r = http_response_init(cmd->w, 0, NULL);
+	if (cmd_is_subscribe(cmd)) {
+		r->keep_alive = 1;
+	}
+	
 	if (r == NULL)
 		return -1;
 


### PR DESCRIPTION
...1, keeping the connection alive from the web socket and enabling the client to manage its lifecycle. This seems to do the trick but I don't know enough about the webdis architecture as to guarantee that there are no side effects. But so far seems to do the trick.
