### PR TITLE
Handle Connection:close header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ B64_OBJS?=b64/cencode.o
 FORMAT_OBJS?=formats/json.o formats/raw.o formats/common.o formats/custom-type.o
 HTTP_PARSER_OBJS?=http-parser/http_parser.o
 
-CFLAGS ?= -g3 -O0 -ggdb -Wall -Wextra -I. -Ijansson/src -Ihttp-parser
+CFLAGS ?= -O0 -ggdb -Wall -Wextra -I. -Ijansson/src -Ihttp-parser
 LDFLAGS ?= -levent -pthread
 
 # check for MessagePack

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ B64_OBJS?=b64/cencode.o
 FORMAT_OBJS?=formats/json.o formats/raw.o formats/common.o formats/custom-type.o
 HTTP_PARSER_OBJS?=http-parser/http_parser.o
 
-CFLAGS ?= -O0 -ggdb -Wall -Wextra -I. -Ijansson/src -Ihttp-parser
+CFLAGS ?= -g3 -O0 -ggdb -Wall -Wextra -I. -Ijansson/src -Ihttp-parser
 LDFLAGS ?= -levent -pthread
 
 # check for MessagePack

--- a/client.c
+++ b/client.c
@@ -180,9 +180,9 @@ http_client_on_message_complete(struct http_parser *p) {
 	struct http_client *c = p->data;
 
 	/* keep-alive detection */
-    if (c->parser.flags & F_CONNECTION_CLOSE) {
-        c->keep_alive = 0;
-    } else if(c->parser.http_major == 1 && c->parser.http_minor == 1) { /* 1.1 */
+	if (c->parser.flags & F_CONNECTION_CLOSE) {
+		c->keep_alive = 0;
+	} else if(c->parser.http_major == 1 && c->parser.http_minor == 1) { /* 1.1 */
 		c->keep_alive = 1;
 	}
 	c->http_version = c->parser.http_minor;

--- a/client.c
+++ b/client.c
@@ -180,7 +180,9 @@ http_client_on_message_complete(struct http_parser *p) {
 	struct http_client *c = p->data;
 
 	/* keep-alive detection */
-	if(c->parser.http_major == 1 && c->parser.http_minor == 1) { /* 1.1 */
+    if (c->parser.flags & F_CONNECTION_CLOSE) {
+        c->keep_alive = 0;
+    } else if(c->parser.http_major == 1 && c->parser.http_minor == 1) { /* 1.1 */
 		c->keep_alive = 1;
 	}
 	c->http_version = c->parser.http_minor;

--- a/http-parser/http_parser.c
+++ b/http-parser/http_parser.c
@@ -288,16 +288,6 @@ enum header_states
   };
 
 
-enum flags
-  { F_CHUNKED               = 1 << 0
-  , F_CONNECTION_KEEP_ALIVE = 1 << 1
-  , F_CONNECTION_CLOSE      = 1 << 2
-  , F_TRAILING              = 1 << 3
-  , F_UPGRADE               = 1 << 4
-  , F_SKIPBODY              = 1 << 5
-  };
-
-
 #define CR '\r'
 #define LF '\n'
 #define LOWER(c) (unsigned char)(c | 0x20)

--- a/http-parser/http_parser.h
+++ b/http-parser/http_parser.h
@@ -165,7 +165,6 @@ enum flags
   };
 
 
-
 void http_parser_init(http_parser *parser, enum http_parser_type type);
 
 

--- a/http-parser/http_parser.h
+++ b/http-parser/http_parser.h
@@ -155,6 +155,17 @@ struct http_parser_settings {
 };
 
 
+enum flags
+  { F_CHUNKED               = 1 << 0
+  , F_CONNECTION_KEEP_ALIVE = 1 << 1
+  , F_CONNECTION_CLOSE      = 1 << 2
+  , F_TRAILING              = 1 << 3
+  , F_UPGRADE               = 1 << 4
+  , F_SKIPBODY              = 1 << 5
+  };
+
+
+
 void http_parser_init(http_parser *parser, enum http_parser_type type);
 
 

--- a/worker.c
+++ b/worker.c
@@ -63,6 +63,8 @@ worker_can_read(int fd, short event, void *p) {
 		if(c->failed_alloc) {
 			slog(c->w->s, WEBDIS_DEBUG, "503", 3);
 			http_send_error(c, 503, "Service Unavailable");
+        } else if (c->parser.flags & F_CONNECTION_CLOSE) {
+            c->broken = 1;
 		} else if(c->is_websocket) {
 			/* we need to use the remaining (unparsed) data as the body. */
 			if(nparsed < ret) {

--- a/worker.c
+++ b/worker.c
@@ -63,8 +63,8 @@ worker_can_read(int fd, short event, void *p) {
 		if(c->failed_alloc) {
 			slog(c->w->s, WEBDIS_DEBUG, "503", 3);
 			http_send_error(c, 503, "Service Unavailable");
-        } else if (c->parser.flags & F_CONNECTION_CLOSE) {
-            c->broken = 1;
+		} else if (c->parser.flags & F_CONNECTION_CLOSE) {
+			c->broken = 1;
 		} else if(c->is_websocket) {
 			/* we need to use the remaining (unparsed) data as the body. */
 			if(nparsed < ret) {


### PR DESCRIPTION
Currently if the `Connection: close` header is sent, the response includes a `Connection: Keep-Alive`.

```
$ curl -v http://127.0.0.1:7379/GET/hello --header "Connection: close"
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 7379 (#0)
> GET /GET/hello HTTP/1.1
> User-Agent: curl/7.38.0
> Host: 127.0.0.1:7379
> Accept: */*
> Connection: close
> 
< HTTP/1.1 200 OK
* Server Webdis is not blacklisted
< Server: Webdis
< Allow: GET,POST,PUT,OPTIONS
< Access-Control-Allow-Methods: GET,POST,PUT,OPTIONS
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Headers: X-Requested-With, Content-Type, Authorization
< Content-Type: application/json
< ETag: "8cf38afc245b7a6a88696566483d1390"
< Connection: Keep-Alive
< Content-Length: 15
< 
* Connection #0 to host 127.0.0.1 left intact
{"GET":"world"}
```

If another request is made using the same connection a `400 Bad Request` is returned.

With this patch, a `Connection: close` header is included in the response instead, so the client will know to close it and use a new connection.

```
$ curl -v http://127.0.0.1:7379/GET/hello --header "Connection: close"
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 7379 (#0)
> GET /GET/hello HTTP/1.1
> User-Agent: curl/7.38.0
> Host: 127.0.0.1:7379
> Accept: */*
> Connection: close
> 
< HTTP/1.1 200 OK
* Server Webdis is not blacklisted
< Server: Webdis
< Allow: GET,POST,PUT,OPTIONS
< Access-Control-Allow-Methods: GET,POST,PUT,OPTIONS
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Headers: X-Requested-With, Content-Type, Authorization
< Content-Type: application/json
< ETag: "8cf38afc245b7a6a88696566483d1390"
< Connection: Close
< Content-Length: 15
< 
* Closing connection 0
{"GET":"world"}
```

The socket is also closed so the client should get a socket read error if it was to attempt another request.

I'm not familiar with the code base, so there might be a better solution, but this works with `curl`, and my own http client library.