### PR TITLE
Improve support for newer msgpack-c releases.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ ifneq ($(findstring yes,$(shell pkg-config --exists msgpack && echo yes)),)
 	CFLAGS += -DMSGPACK=1 $(shell pkg-config --cflags msgpack)
 	LDFLAGS += $(shell pkg-config --libs msgpack)
 else
-	MSGPACK_LIB=$(shell ls /usr/lib/libmsgpack.so 2>/dev/null)
+	MSGPACK_LIB=$(shell ls /usr/lib/libmsgpackc.so /usr/lib/*/libmsgpackc.so 2>/dev/null)
 	ifneq ($(strip $(MSGPACK_LIB)),)
 		FORMAT_OBJS += formats/msgpack.o
 		CFLAGS += -DMSGPACK=1
-		LDFLAGS += -lmsgpack
+		LDFLAGS += -lmsgpackc
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,17 @@ CFLAGS ?= -O0 -ggdb -Wall -Wextra -I. -Ijansson/src -Ihttp-parser
 LDFLAGS ?= -levent -pthread
 
 # check for MessagePack
-MSGPACK_LIB=$(shell ls /usr/lib/libmsgpack.so 2>/dev/null)
-ifneq ($(strip $(MSGPACK_LIB)),)
+ifneq ($(findstring yes,$(shell pkg-config --exists msgpack && echo yes)),)
 	FORMAT_OBJS += formats/msgpack.o
-	CFLAGS += -DMSGPACK=1
-	LDFLAGS += -lmsgpack
+	CFLAGS += -DMSGPACK=1 $(shell pkg-config --cflags msgpack)
+	LDFLAGS += $(shell pkg-config --libs msgpack)
+else
+	MSGPACK_LIB=$(shell ls /usr/lib/libmsgpack.so 2>/dev/null)
+	ifneq ($(strip $(MSGPACK_LIB)),)
+		FORMAT_OBJS += formats/msgpack.o
+		CFLAGS += -DMSGPACK=1
+		LDFLAGS += -lmsgpack
+	endif
 endif
 
 

--- a/formats/msgpack.c
+++ b/formats/msgpack.c
@@ -8,6 +8,18 @@
 #include <hiredis/hiredis.h>
 #include <hiredis/async.h>
 
+/* msgpack-c versions >= 1.0 changed to support the v5 msgpack spec.
+ * As part of doing this, the (un)pack_raw functions were replaced with
+ * more explicit (un)pack_str and (un)pack_bin.  1.2.0 introduced the
+ * (un)pack_v4raw functions to retain compatibility.
+ */
+#if defined(MSGPACK_VERSION_MAJOR) && defined(MSGPACK_VERSION_MINOR) \
+	&& MSGPACK_VERSION_MAJOR > 1 \
+	|| (MSGPACK_VERSION_MAJOR == 1 && MSGPACK_VERSION_MINOR >= 2)
+#define msgpack_pack_raw msgpack_pack_v4raw
+#define msgpack_pack_raw_body msgpack_pack_v4raw_body
+#endif
+
 struct msg_out {
 	char *p;
 	size_t sz;


### PR DESCRIPTION
- Leverage msgpack's pkg-config information when available
- Enable building against newer (>= 1.2.0) msgpack-c releases,
  which had to make incompatible changes to accomodate changes
  in the msgpack spec itself.
