### PR TITLE
convert pub/sub response to valid json when you have multiple messages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -309,6 +309,11 @@ function checkData() {
     	chunk = response.slice(previous_response_length);
     	previous_response_length = response.length;
     	console.log(chunk);
+//if you get messages faster than you can parse one at a time- convert to valid json first
+      var replacedChunk = chunk.replace(/}{"SUBSCRIBE":/g, '},{"SUBSCRIBE":     ');
+      var validJSON = '['+replacedChunk+']'
+      var json = JSON.parse(validJSON);
+      console.log(json);
     }
 };
 </pre>


### PR DESCRIPTION
My chunk response looks like this:

`{"SUBSCRIBE":["subscribe","status:58b1af25b5e1b5271b82d62e",1]}{"SUBSCRIBE":["message","status:58b1af25b5e1b5271b82d62e","test message."]}`

However I cannot do a `JSON.parse(chunk)` because this is not valid json. My solution formats the response to valid json so that is parsable