### PR TITLE
Fix crash when subscribed connections are closed #155

### DIFF
--- a/client.c
+++ b/client.c
@@ -291,7 +291,8 @@ http_client_read(struct http_client *c) {
 
 			/* disconnect from all channels */
 			redisAsyncDisconnect(c->pub_sub->ac);
-			if(c->pub_sub) c->pub_sub->ac = NULL;
+			// c->pub_sub might be already cleared by an event handler in redisAsyncDisconnect
+			cmd->ac = NULL;
 			c->pub_sub = NULL;
 
 			/* delete command object */


### PR DESCRIPTION
This fixes #155.

Background: 
The following line is called during redisAsyncDisconnect (see backtrace below)
https://github.com/nicolasff/webdis/blob/91a8ea3a506d7a70449154863c32228c998d5e87/formats/common.c#L51

So the ac-member has not been set to NULL here, as pub_sub is zero.
https://github.com/nicolasff/webdis/blob/91a8ea3a506d7a70449154863c32228c998d5e87/client.c#L294

```
#0  format_send_error (cmd=0x7ffff00096b0, code=503, msg=0x555555576364 "Service Unavailable") at formats/common.c:55
#1  0x000055555555f532 in json_reply (c=0x7ffff0009b10, r=0x0, privdata=0x7ffff00096b0) at formats/json.c:29
#2  0x00005555555680e8 in __redisRunCallback (ac=0x7ffff0009b10, cb=0x7ffff0009e30, reply=0x0) at hiredis/async.c:269
#3  0x00005555555681cc in __redisAsyncFree (ac=0x7ffff0009b10) at hiredis/async.c:292
#4  0x0000555555568413 in __redisAsyncDisconnect (ac=0x7ffff0009b10) at hiredis/async.c:348
#5  0x0000555555568470 in redisAsyncDisconnect (ac=0x7ffff0009b10) at hiredis/async.c:361
#6  0x000055555555c9a6 in http_client_read (c=0x555555781680) at client.c:293
#7  0x0000555555557784 in worker_can_read (fd=133, event=2, p=0x555555781680) at worker.c:45
#8  0x00007ffff7ba2a11 in ?? () from /usr/lib/x86_64-linux-gnu/libevent-2.1.so.6
#9  0x00007ffff7ba333f in event_base_loop () from /usr/lib/x86_64-linux-gnu/libevent-2.1.so.6
#10 0x0000555555557c1a in worker_main (p=0x555555781190) at worker.c:158
#11 0x00007ffff796c6db in start_thread (arg=0x7ffff7573700) at pthread_create.c:463
#12 0x00007ffff769588f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```