### PR TITLE
Fixed websocket not reading multiple messages in one packet

### DIFF
--- a/websocket.c
+++ b/websocket.c
@@ -310,7 +310,7 @@ ws_add_data(struct http_client *c) {
 
 	state = ws_parse_data(c->buffer, c->sz, &c->frame);
 
-	if(state == WS_MSG_COMPLETE) {
+	while(state == WS_MSG_COMPLETE) {
 		int ret = ws_execute(c, c->frame->payload, c->frame->payload_sz);
 
 		/* remove frame from client buffer */
@@ -323,6 +323,7 @@ ws_add_data(struct http_client *c) {
 			/* can't process frame. */
 			return WS_ERROR;
 		}
+		state = ws_parse_data(c->buffer, c->sz, &c->frame);
 	}
 	return state;
 }


### PR DESCRIPTION
While using chrome and subscribing to multiple (64 was my case) keys in a for loop, webdis will drop requests when the requests are grouped into a single network packet. I assume that the grouping is because of Nagle's algorithm.

This pull request is my proposal to fix issue #159 