### PR TITLE
Add missing Make dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ webdis
 websocket
 *.png
 pubsub
+*.d

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ B64_OBJS?=b64/cencode.o
 FORMAT_OBJS?=formats/json.o formats/raw.o formats/common.o formats/custom-type.o
 HTTP_PARSER_OBJS?=http-parser/http_parser.o
 
-CFLAGS ?= -O0 -ggdb -Wall -Wextra -I. -Ijansson/src -Ihttp-parser
+CFLAGS ?= -O0 -ggdb -Wall -Wextra -I. -Ijansson/src -Ihttp-parser -MD
 LDFLAGS ?= -levent -pthread
 
 # check for MessagePack
@@ -17,6 +17,8 @@ ifneq ($(strip $(MSGPACK_LIB)),)
 endif
 
 
+
+OBJS_DEPS=$(wildcard *.d)
 DEPS=$(FORMAT_OBJS) $(HIREDIS_OBJ) $(JANSSON_OBJ) $(HTTP_PARSER_OBJS) $(B64_OBJS)
 OBJS=webdis.o cmd.o worker.o slog.o server.o acl.o md5/md5.o sha1/sha1.o http.o client.o websocket.o pool.o conf.o $(DEPS)
 
@@ -45,7 +47,7 @@ $(INSTALL_DIRS):
 	mkdir -p $@
 
 clean:
-	rm -f $(OBJS) $(OUT)
+	rm -f $(OBJS) $(OUT) $(OBJS_DEPS)
 
 install: $(OUT) $(INSTALL_DIRS)
 	cp $(OUT) $(DESTDIR)/$(PREFIX)/bin
@@ -64,3 +66,5 @@ test:
 perftest:
 	# This is a performance test that requires apache2-utils and curl
 	./tests/bench.sh
+
+-include $(OBJS:.o=.d)


### PR DESCRIPTION
Hello

This pull request fixes the build script of this project.
Specifically, it adds missing Make dependencies so that the targets of the project are re-generated correctly whenever there are updates to any of the dependent source files.

In this way, the project is incrementally built and we no longer sacrifice time in clean builds (i.e., builds after a make clean).

Note that this fix follows the best practices for tracking dependencies automatically (through gcc -MD)

For more details, see here.
https://www.gnu.org/software/make/manual/html_node/Automatic-Prerequisites.html