### PR TITLE
Ensure websockets write all data; Always keep_alive every websocket

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -380,9 +380,7 @@ ws_reply(struct cmd *cmd, const char *p, size_t sz) {
 
 	/* send WS frame */
 	r = http_response_init(cmd->w, 0, NULL);
-	if (cmd_is_subscribe(cmd)) {
-		r->keep_alive = 1;
-	}
+	r->keep_alive = 1;
 	
 	if (r == NULL)
 		return -1;


### PR DESCRIPTION
Summary:

- Ensure websockets write all data

- Always keep_alive every websocket

Explanation:

I've been using webdis websockets to write large amounts of data to a webgl demo for plotting lots of data points (https://twitter.com/theshawwn/status/1292266967940960257). There were two hurdles:

1. webdis doesn't handle the return value of `write()` properly, leading to truncated sends

2. webdis seems to close websockets after each request.

This PR writes all data, and also marks every websocket as `keep_alive = 1`, ensuring that it stays open for multiple requests.

There is currently a demo of this here: http://test.tensorfork.com/ though I'm not sure how long that link will remain valid.



