### PR TITLE
Implement Redis v6 auth (fixes #182) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ f0a2763fd456
 * WebSocket support (Currently using the “hixie-76” specification).
 * Connects to Redis using a TCP or UNIX socket.
 * Restricted commands by IP range (CIDR subnet + mask) or HTTP Basic Auth, returning 403 errors.
-* Possible Redis authentication in the config file.
+* Support for Redis authentication in the config file: set `redis_auth` to a single string to use a password value, or to an array of two strings to use username+password auth ([new in Redis 6.0](https://redis.io/commands/auth)).
 * Environment variables can be used as values in the config file, starting with `$` and in all caps (e.g. `$REDIS_HOST`).
 * Pub/Sub using `Transfer-Encoding: chunked`, works with JSONP as well. Webdis can be used as a Comet server.
 * Drop privileges on startup.

--- a/src/conf.c
+++ b/src/conf.c
@@ -113,7 +113,7 @@ conf_read(const char *filename) {
 				conf->redis_auth = conf_auth_legacy(conf_string_or_envvar(json_string_value(jtmp)));
 			} else if(json_typeof(jtmp) == JSON_ARRAY) {
 				conf->redis_auth = conf_auth_username_password(jtmp);
-			} else {
+			} else if(json_typeof(jtmp) != JSON_NULL) {
 				fprintf(stderr, ACL_ERROR_PREFIX "expected a string or an array of two strings" ACL_ERROR_SUFFIX);
 			}
 		} else if(strcmp(json_object_iter_key(kv), "http_host") == 0 && json_typeof(jtmp) == JSON_STRING) {
@@ -302,6 +302,10 @@ void
 conf_free(struct conf *conf) {
 
 	free(conf->redis_host);
+	if(conf->redis_auth) {
+		free(conf->redis_auth->username);
+		free(conf->redis_auth->password);
+	}
 	free(conf->redis_auth);
 
 	free(conf->http_host);

--- a/src/conf.h
+++ b/src/conf.h
@@ -4,12 +4,19 @@
 #include <sys/types.h>
 #include "slog.h"
 
+struct auth {
+	/* 1 if only password is used, 0 for username + password */
+	int use_legacy_auth;
+	char *username;
+	char *password;
+};
+
 struct conf {
 
 	/* connection to Redis */
 	char *redis_host;
 	int redis_port;
-	char *redis_auth;
+	struct auth *redis_auth;
 
 	/* HTTP server interface */
 	char *http_host;

--- a/src/pool.c
+++ b/src/pool.c
@@ -154,7 +154,14 @@ pool_connect(struct pool *p, int db_num, int attach) {
 	redisAsyncSetDisconnectCallback(ac, pool_on_disconnect);
 
 	if(p->cfg->redis_auth) { /* authenticate. */
-		redisAsyncCommand(ac, NULL, NULL, "AUTH %s", p->cfg->redis_auth);
+		if(p->cfg->redis_auth->use_legacy_auth) {
+			redisAsyncCommand(ac, NULL, NULL, "AUTH %s",
+				p->cfg->redis_auth->password);
+		} else {
+			redisAsyncCommand(ac, NULL, NULL, "AUTH %s %s",
+				p->cfg->redis_auth->username,
+				p->cfg->redis_auth->password);
+		}
 	}
 	if(db_num) { /* change database. */
 		redisAsyncCommand(ac, NULL, NULL, "SELECT %d", db_num);

--- a/src/server.c
+++ b/src/server.c
@@ -104,6 +104,8 @@ server_new(const char *cfg_file) {
 	for(i = 0; i < s->cfg->http_threads; ++i) {
 		s->w[i] = worker_new(s);
 	}
+
+	pthread_mutex_init(&s->auth_log_mutex, NULL);
 	return s;
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -25,6 +25,10 @@ struct server {
 		pid_t self;
 		int fd;
 	} log;
+
+	/* used to log auth message only once */
+	pthread_mutex_t auth_log_mutex;
+	int auth_logged;
 };
 
 struct server *

--- a/src/slog.c
+++ b/src/slog.c
@@ -49,7 +49,7 @@ void
 slog(struct server *s, log_level level,
 		const char *body, size_t sz) {
 
-	const char *c = ".-*#";
+	const char *c = "EWNID";
 	time_t now;
 	struct tm now_tm, *lt_ret;
 	char time_buf[64];
@@ -77,7 +77,7 @@ slog(struct server *s, log_level level,
 
 	/* generate output line. */
 	line_sz = snprintf(line, sizeof(line),
-		"[%d] %s %d %s\n", (int)s->log.self, time_buf, c[level], msg);
+		"[%d] %s %c %s\n", (int)s->log.self, time_buf, c[level], msg);
 
 	/* write to log and flush to disk. */
 	ret = write(s->log.fd, line, line_sz);


### PR DESCRIPTION
There are 3 commits in this PR:
1. 4640ac0 adds support for Redis 6 auth with a username and password
2. f159c7f fixes an issue I noticed in `slog.c` while writing this
3. d3d40bd adds logging for the `AUTH` command; webdis is currently ignoring the response from Redis and just relying on later commands failing to notify users that the current config doesn't work correctly

CC @nicolasff 