### PR TITLE
Warning fixes

### DIFF
--- a/src/b64/cencode.c
+++ b/src/b64/cencode.c
@@ -48,6 +48,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			result = (fragment & 0x0fc) >> 2;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x003) << 4;
+			/* fall through */
 	case step_B:
 			if (plainchar == plaintextend)
 			{
@@ -59,6 +60,7 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			result |= (fragment & 0x0f0) >> 4;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x00f) << 2;
+			/* fall through */
 	case step_C:
 			if (plainchar == plaintextend)
 			{

--- a/src/conf.c
+++ b/src/conf.c
@@ -199,7 +199,6 @@ acl_read_commands(json_t *jlist, struct acl_commands *ac) {
 	for(i = 0, cur = 0; i < json_array_size(jlist); ++i) {
 		json_t *jelem = json_array_get(jlist, i);
 		if(json_typeof(jelem) == JSON_STRING) {
-			size_t sz;
 			ac->commands[cur] = conf_string_or_envvar(json_string_value(jelem));
 			cur++;
 		}
@@ -241,7 +240,7 @@ conf_parse_acl(json_t *j) {
 		base64_encodestate b64;
 		int pos;
 		char *p;
-		const char *plain = conf_string_or_envvar(json_string_value(jbasic));
+		char *plain = conf_string_or_envvar(json_string_value(jbasic));
 		size_t len, plain_len = strlen(plain) + 0;
 		len = (plain_len + 8) * 8 / 6;
 		a->http_basic_auth = calloc(len, 1);

--- a/src/formats/msgpack.c
+++ b/src/formats/msgpack.c
@@ -167,7 +167,7 @@ static void
 msgpack_wrap_redis_reply(const struct cmd *cmd, struct msg_out *out, const redisReply *r) {
 
 	unsigned int i;
-	msgpack_packer* pk = msgpack_packer_new(out, on_msgpack_write);
+	msgpack_packer* pk = msgpack_packer_new(out, (msgpack_packer_write)on_msgpack_write);
 
 	/* copy verb, as jansson only takes a char* but not its length. */
 	char *verb = "";

--- a/src/hiredis/dict.c
+++ b/src/hiredis/dict.c
@@ -39,6 +39,12 @@
 #include <limits.h>
 #include "dict.h"
 
+#ifdef __GNUC__
+#define __UNUSED_FUNCTION__ __attribute__ ((unused))
+#else
+#define __UNUSED_FUNCTION__
+#endif
+
 /* -------------------------- private prototypes ---------------------------- */
 
 static int _dictExpandIfNeeded(dict *ht);
@@ -50,6 +56,7 @@ static int _dictInit(dict *ht, dictType *type, void *privDataPtr);
 
 /* Generic hash function (a popular one from Bernstein).
  * I tested a few and this was the best. */
+__UNUSED_FUNCTION__
 static unsigned int dictGenHashFunction(const unsigned char *buf, int len) {
     unsigned int hash = 5381;
 
@@ -70,6 +77,7 @@ static void _dictReset(dict *ht) {
 }
 
 /* Create a new hash table */
+__UNUSED_FUNCTION__
 static dict *dictCreate(dictType *type, void *privDataPtr) {
     dict *ht = malloc(sizeof(*ht));
     _dictInit(ht,type,privDataPtr);
@@ -157,6 +165,7 @@ static int dictAdd(dict *ht, void *key, void *val) {
  * Return 1 if the key was added from scratch, 0 if there was already an
  * element with such key and dictReplace() just performed a value update
  * operation. */
+__UNUSED_FUNCTION__
 static int dictReplace(dict *ht, void *key, void *val) {
     dictEntry *entry, auxentry;
 
@@ -179,6 +188,7 @@ static int dictReplace(dict *ht, void *key, void *val) {
 }
 
 /* Search and remove an element */
+__UNUSED_FUNCTION__
 static int dictDelete(dict *ht, const void *key) {
     unsigned int h;
     dictEntry *de, *prevde;
@@ -235,6 +245,7 @@ static int _dictClear(dict *ht) {
 }
 
 /* Clear & Release the hash table */
+__UNUSED_FUNCTION__
 static void dictRelease(dict *ht) {
     _dictClear(ht);
     free(ht);
@@ -255,6 +266,7 @@ static dictEntry *dictFind(dict *ht, const void *key) {
     return NULL;
 }
 
+__UNUSED_FUNCTION__
 static dictIterator *dictGetIterator(dict *ht) {
     dictIterator *iter = malloc(sizeof(*iter));
 
@@ -265,6 +277,7 @@ static dictIterator *dictGetIterator(dict *ht) {
     return iter;
 }
 
+__UNUSED_FUNCTION__
 static dictEntry *dictNext(dictIterator *iter) {
     while (1) {
         if (iter->entry == NULL) {
@@ -285,6 +298,7 @@ static dictEntry *dictNext(dictIterator *iter) {
     return NULL;
 }
 
+__UNUSED_FUNCTION__
 static void dictReleaseIterator(dictIterator *iter) {
     free(iter);
 }

--- a/src/slog.c
+++ b/src/slog.c
@@ -72,7 +72,7 @@ slog(struct server *s, log_level level,
 		strftime(time_buf, sizeof(time_buf), "%d %b %H:%M:%S", lt_ret);
 	} else {
 		const char err_msg[] = "(NO TIME AVAILABLE)";
-		strncpy(time_buf, err_msg, sizeof(err_msg));
+		memcpy(time_buf, err_msg, sizeof(err_msg));
 	}
 
 	/* generate output line. */


### PR DESCRIPTION
I fixed a few compilation warnings: 2 in `conf.c` from the recent changes I made there, and also in `dict.c` where some functions are unused and cause a warning. I noticed also that hiredis was from an old import, maybe it should be upgraded?

1. Remove unused size_t sz variable
2. Remove const on free()'d variable
3. Remove unused function warning in dict.c