### PR TITLE
Make fsync frequency configurable for log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ f0a2763fd456
 * Custom Content-Type using a pre-defined file extension, or with `?type=some/thing`.
 * URL-encoded parameters for binary data or slashes and question marks. For instance, `%2f` is decoded as `/` but not used as a command separator.
 * Logs, with a configurable verbosity.
+* Configurable `fsync` frequency for the log file:
+    * Set `"log_fsync": "auto"` (default) to let the file system handle file persistence on its own.
+    * Set `"log_fsync": N` where `N` is a number to call `fsync` every `N` milliseconds.
+    * Set `"log_fsync": "all"` (very slow) to persist the log file to its storage device on each log message.
 * Cross-origin requests, usable with XMLHttpRequest2 (Cross-Origin Resource Sharing - CORS).
 * File upload with PUT.
 * With the JSON output, the return value of INFO is parsed and transformed into an object.

--- a/src/conf.c
+++ b/src/conf.c
@@ -86,6 +86,7 @@ conf_read(const char *filename) {
 	conf->user = getuid();
 	conf->group = getgid();
 	conf->logfile = "webdis.log";
+	conf->log_fsync.mode = LOG_FSYNC_AUTO;
 	conf->verbosity = WEBDIS_NOTICE;
 	conf->daemonize = 0;
 	conf->pidfile = "webdis.pid";
@@ -145,6 +146,17 @@ conf_read(const char *filename) {
 			}
 		} else if(strcmp(json_object_iter_key(kv),"logfile") == 0 && json_typeof(jtmp) == JSON_STRING){
 			conf->logfile = conf_string_or_envvar(json_string_value(jtmp));
+		} else if(strcmp(json_object_iter_key(kv),"log_fsync") == 0) {
+			if(json_typeof(jtmp) == JSON_STRING && strcmp(json_string_value(jtmp), "auto") == 0) {
+				conf->log_fsync.mode = LOG_FSYNC_AUTO;
+			} else if(json_typeof(jtmp) == JSON_STRING && strcmp(json_string_value(jtmp), "all") == 0) {
+				conf->log_fsync.mode = LOG_FSYNC_ALL;
+			} else if(json_typeof(jtmp) == JSON_INTEGER && json_integer_value(jtmp) > 0) {
+				conf->log_fsync.mode = LOG_FSYNC_MILLIS;
+				conf->log_fsync.period_millis = (int)json_integer_value(jtmp);
+			} else if(json_typeof(jtmp) != JSON_NULL) {
+				fprintf(stderr, "Unexpected value for \"log_fsync\", defaulting to \"auto\"\n");
+			}
 		} else if(strcmp(json_object_iter_key(kv),"verbosity") == 0 && json_typeof(jtmp) == JSON_INTEGER){
 			int tmp = json_integer_value(jtmp);
 			if(tmp < 0) conf->verbosity = WEBDIS_ERROR;

--- a/src/conf.h
+++ b/src/conf.h
@@ -47,6 +47,10 @@ struct conf {
 	/* Logging */
 	char *logfile;
 	log_level verbosity;
+	struct {
+		log_fsync_mode mode;
+		int period_millis; /* only used with LOG_FSYNC_MILLIS */
+	} log_fsync;
 
 	/* Request to serve on “/” */
 	char *default_root;

--- a/src/server.c
+++ b/src/server.c
@@ -177,6 +177,7 @@ static struct server *__server;
 static void
 server_handle_signal(int id) {
 
+	int ret;
 	switch(id) {
 		case SIGHUP:
 			slog_init(__server);
@@ -184,6 +185,8 @@ server_handle_signal(int id) {
 		case SIGTERM:
 		case SIGINT:
 			slog(__server, WEBDIS_INFO, "Webdis terminating", 0);
+			ret = fsync(__server->log.fd);
+			(void)ret;
 			exit(0);
 			break;
 		default:
@@ -251,6 +254,9 @@ server_start(struct server *s) {
 		slog(s, WEBDIS_ERROR, "Error calling event_add on socket", 0);
 		return -1;
 	}
+
+	/* initialize fsync timer once libevent is set up */
+	slog_fsync_init(s);
 
 	slog(s, WEBDIS_INFO, "Webdis " WEBDIS_VERSION " up and running", 0);
 	event_base_dispatch(s->base);

--- a/src/server.h
+++ b/src/server.h
@@ -24,6 +24,8 @@ struct server {
 	struct {
 		pid_t self;
 		int fd;
+		struct timeval fsync_tv;
+		struct event *fsync_ev;
 	} log;
 
 	/* used to log auth message only once */

--- a/src/slog.h
+++ b/src/slog.h
@@ -9,6 +9,12 @@ typedef enum {
 	WEBDIS_DEBUG
 } log_level;
 
+typedef enum {
+	LOG_FSYNC_AUTO = 0,
+	LOG_FSYNC_MILLIS,
+	LOG_FSYNC_ALL
+} log_fsync_mode;
+
 struct server;
 
 void
@@ -16,6 +22,9 @@ slog_reload();
 
 void
 slog_init(struct server *s);
+
+void
+slog_fsync_init(struct server *s);
 
 void slog(struct server *s, log_level level,
 		const char *body, size_t sz);

--- a/webdis.json
+++ b/webdis.json
@@ -26,6 +26,6 @@
 		}
 	],
 
-        "verbosity": 6,
-        "logfile": "webdis.log"
+	"verbosity": 6,
+	"logfile": "webdis.log"
 }


### PR DESCRIPTION
Webdis calls fsync after every single log message, which had a significant negative impact on performance. This change introduces 3 config options for fsync: no explicit fsync (the new default), a periodic fsync called every N milliseconds, or the old behavior.

The new config key is also documented and validates its inputs.

@nicolasff I modeled the different options after Cassandra as you suggested, this should be flexible enough for everyone. I changed the default to never explicitly fsync, which is a change from the current behavior but seems to me like a better default value. Let me know what you think. I also made it use Libevent rather than a separate thread for simplicity.

Here are the numbers I got on my machine with `ab` calling `PING` 1 million times with 200 clients ([Gist with details](https://gist.github.com/jessie-murray/5cabd070b29d14dfc9246697688284cb)):
* With `"auto"`: 92,456 requests/sec, 95th percentile 3ms, 99th percentile 3ms, longest 28ms
* With `50`: 91,490 requests/sec, 95th percentile 3ms, 99th percentile 3ms, longest 29ms
* With `"all"`: 20,480 requests/sec, 95th percentile 13ms, 99th percentile 15ms, longest 52ms

Even with `10` the numbers were similar to `50` or `100`, it's really when the file is fsync'd after each write that the impact is significant.