### PR TITLE
Add support for REDIS_REPLY_STATUS in nested JSON

### DIFF
--- a/src/formats/json.c
+++ b/src/formats/json.c
@@ -151,6 +151,7 @@ json_expand_array(const redisReply *r) {
 	for(i = 0; i < r->elements; ++i) {
 		e = r->element[i];
 		switch(e->type) {
+		case REDIS_REPLY_STATUS:
 		case REDIS_REPLY_STRING:
 			json_array_append_new(jlist, json_string(e->str));
 			break;


### PR DESCRIPTION
When strings are added as elements of an array but typed as `REDIS_REPLY_STATUS` instead of `REDIS_REPLY_STRING`, Webdis encodes them as nulls. `REDIS_REPLY_STATUS` should only be encoded as `[true, str]` or `[false, str]` when this is a top-level status response, not an array element. In these cases we only need the string.

Fixes #188