### PR TITLE
Only process `Connection: close` header if full request was read (fixes #194)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         apt-get -y update
-        apt-get -y --force-yes install make gcc libevent-dev libmsgpack-dev python3
+        apt-get -y --force-yes install make gcc libevent-dev libmsgpack-dev python3 curl
     - name: Build
       run: make
     - name: Run Webdis and test
@@ -25,6 +25,7 @@ jobs:
         ./webdis .github/workflows/webdis-ci.json
         sleep 2
         ./tests/basic.py
+        ./tests/curl-tests.sh
     - name: Archive logs
       uses: actions/upload-artifact@v2
       with:

--- a/src/client.c
+++ b/src/client.c
@@ -182,6 +182,7 @@ http_client_on_message_complete(struct http_parser *p) {
 	/* keep-alive detection */
 	if (c->parser.flags & F_CONNECTION_CLOSE) {
 		c->keep_alive = 0;
+		c->fully_read = 1; /* only *now* can we stop waiting for input */
 	} else if(c->parser.http_major == 1 && c->parser.http_minor == 1) { /* 1.1 */
 		c->keep_alive = 1;
 	}

--- a/src/client.h
+++ b/src/client.h
@@ -40,6 +40,7 @@ struct http_client {
 	/* various flags. */
 	char keep_alive;
 	char broken;
+	char fully_read;
 	char is_websocket;
 	char http_version;
 	char failed_alloc;

--- a/src/worker.c
+++ b/src/worker.c
@@ -63,7 +63,8 @@ worker_can_read(int fd, short event, void *p) {
 		if(c->failed_alloc) {
 			slog(c->w->s, WEBDIS_DEBUG, "503", 3);
 			http_send_error(c, 503, "Service Unavailable");
-		} else if (c->parser.flags & F_CONNECTION_CLOSE) {
+		} else if (c->parser.flags & F_CONNECTION_CLOSE && c->fully_read) {
+			/* only close if requested *and* we've already read the request in full */
 			c->broken = 1;
 		} else if(c->is_websocket) {
 			/* we need to use the remaining (unparsed) data as the body. */

--- a/tests/curl-tests.sh
+++ b/tests/curl-tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# exit on first error
+set -e
+
+# GitHub issue #194 (connection: close + HTTP 100)
+printf 'A%.0s' $(seq 1 10000) | curl -v -H 'Connection: close' -XPUT 'http://127.0.0.1:7379/SET/toobig' -d @-
+if [[ $(curl -v 'http://127.0.0.1:7379/STRLEN/toobig.txt') != '10000' ]]; then exit 1; fi


### PR DESCRIPTION
The presence of a `Connection: close` header sets a flag on the request,
which we process by no longer running the HTTP parser as soon as it
returns from parsing a chunk. Since HTTP 100 uploads require at least 2
reads, we need to handle the `Connection: close` only if we've reached
the end of the request. This change sets a flag in `on_message_complete`,
which we use in combination with the header to stop reading.

Also adding a test to reproduce this issue and including it in CI job.

@nicolasff I tried to find an existing flag but didn't find anything already set in `http_client_on_message_complete` that I could use. There's `c->keep_alive = 0` just above the flag I set, but it's 0 by default due to the `calloc` so I don't think it's a reliable indicator that the request has been fully parsed. I was also thinking there might be something inside the parser object itself but I didn't really want to rely on its internals (what if it changes later?). But if you have a better idea it might avoid this 1-byte increase, even though this is very small and might actually not make any difference due to alignment.w