### PR TITLE
Websocket test fixes

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -159,9 +159,11 @@ conf_read(const char *filename) {
 			}
 		} else if(strcmp(json_object_iter_key(kv),"verbosity") == 0 && json_typeof(jtmp) == JSON_INTEGER){
 			int tmp = json_integer_value(jtmp);
-			if(tmp < 0) conf->verbosity = WEBDIS_ERROR;
-			else if(tmp > (int)WEBDIS_DEBUG) conf->verbosity = WEBDIS_DEBUG;
-			else conf->verbosity = (log_level)tmp;
+			if(tmp < 0 || tmp > (int)WEBDIS_TRACE) {
+				fprintf(stderr, "Invalid log verbosity: %d. Acceptable range: [%d .. %d]\n",
+					tmp, WEBDIS_ERROR, WEBDIS_TRACE);
+			}
+			conf->verbosity = (tmp < 0 ? WEBDIS_ERROR : (tmp > WEBDIS_TRACE ? WEBDIS_TRACE : (log_level)tmp));
 		} else if(strcmp(json_object_iter_key(kv), "daemonize") == 0 && json_typeof(jtmp) == JSON_TRUE) {
 			conf->daemonize = 1;
 		} else if(strcmp(json_object_iter_key(kv), "daemonize") == 0 && json_typeof(jtmp) == JSON_STRING) {

--- a/src/http.c
+++ b/src/http.c
@@ -98,6 +98,7 @@ http_response_cleanup(struct http_response *r, int fd, int success) {
 	free(r->out);
 	if(!r->keep_alive || !success) {
 		/* Close fd is client doesn't support Keep-Alive. */
+		fprintf(stderr, "http_response_cleanup: keep_alive=%d, success=%d -> closing\n", r->keep_alive, success);
 		close(fd);
 	}
 
@@ -124,6 +125,8 @@ http_can_write(int fd, short event, void *p) {
 	if(ret > 0)
 		r->sent += ret;
 
+	fprintf(stderr, "http_can_write: ret=%d, r->out_sz=%lu, r->sent=%d\n",
+		ret, r->out_sz, r->sent);
 	if(ret <= 0 || r->out_sz - r->sent == 0) { /* error or done */
 		http_response_cleanup(r, fd, (int)r->out_sz == r->sent ? 1 : 0);
 	} else { /* reschedule write */

--- a/src/http.c
+++ b/src/http.c
@@ -2,7 +2,6 @@
 #include "server.h"
 #include "worker.h"
 #include "client.h"
-#include "slog.h"
 
 #include <string.h>
 #include <stdlib.h>
@@ -99,12 +98,6 @@ http_response_cleanup(struct http_response *r, int fd, int success) {
 	free(r->out);
 	if(!r->keep_alive || !success) {
 		/* Close fd is client doesn't support Keep-Alive. */
-		if (r->w && slog_enabled(r->w->s, WEBDIS_TRACE)) {
-			char format[] = "http_response_cleanup: keep_alive=%d, success=%d -> closing";
-			char cleanup_msg[sizeof(format)];
-			snprintf(cleanup_msg, sizeof(cleanup_msg), format, r->keep_alive ? 1 : 0, success ? 1: 0);
-			slog(r->w->s, WEBDIS_TRACE, cleanup_msg, 0);
-		}
 		close(fd);
 	}
 
@@ -130,19 +123,6 @@ http_can_write(int fd, short event, void *p) {
 
 	if(ret > 0)
 		r->sent += ret;
-
-	if (r->w && slog_enabled(r->w->s, WEBDIS_TRACE)) { /* trace logs */
-		char format[] = "http_can_write: wrote %d, remaining=%lu, total sent=%d";
-		size_t contents_sz = snprintf(NULL, 0, format, ret, r->out_sz - r->sent, r->sent);
-		char *contents_msg = calloc(contents_sz + 1, 1);
-		if (contents_msg) {
-			snprintf(contents_msg, contents_sz + 1, format, ret, r->out_sz - r->sent, r->sent);
-			slog(r->w->s, WEBDIS_TRACE, contents_msg, contents_sz);
-			free(contents_msg);
-		} else {
-			slog(r->w->s, WEBDIS_ERROR, "Failed allocation in http_can_write", 0);
-		}
-	}
 
 	if(ret <= 0 || r->out_sz - r->sent == 0) { /* error or done */
 		http_response_cleanup(r, fd, (int)r->out_sz == r->sent ? 1 : 0);

--- a/src/slog.c
+++ b/src/slog.c
@@ -77,11 +77,21 @@ slog_fsync_init(struct server *s) {
 }
 
 /**
+ * Returns whether this log level is enabled.
+ */
+int
+slog_enabled(struct server *s, log_level level) {
+	return level <= s->cfg->verbosity ? 1 : 0;
+}
+
+/**
  * Write log message to disk, or stderr.
  */
 void
 slog(struct server *s, log_level level,
 		const char *body, size_t sz) {
+
+	if(level > s->cfg->verbosity) return; /* too verbose */
 
 	const char *c = "EWNID";
 	time_t now;
@@ -90,8 +100,6 @@ slog(struct server *s, log_level level,
 	char msg[124];
 	char line[256]; /* bounds are checked. */
 	int line_sz, ret;
-
-	if(level > s->cfg->verbosity) return; /* too verbose */
 
 	if(!s->log.fd) return;
 

--- a/src/slog.c
+++ b/src/slog.c
@@ -87,13 +87,11 @@ slog_enabled(struct server *s, log_level level) {
 /**
  * Write log message to disk, or stderr.
  */
-void
-slog(struct server *s, log_level level,
+static void
+slog_internal(struct server *s, log_level level,
 		const char *body, size_t sz) {
 
-	if(level > s->cfg->verbosity) return; /* too verbose */
-
-	const char *c = "EWNID";
+	const char *c = "EWNIDT";
 	time_t now;
 	struct tm now_tm, *lt_ret;
 	char time_buf[64];
@@ -128,4 +126,15 @@ slog(struct server *s, log_level level,
 	}
 
 	(void)ret;
+}
+
+/**
+ * This wrapper around slog_internal that first checks the log level.
+ */
+void
+slog(struct server *s, log_level level,
+		const char *body, size_t sz) {
+	if(level <= s->cfg->verbosity) { /* check log level first */
+		slog_internal(s, level, body, sz);
+	}
 }

--- a/src/slog.c
+++ b/src/slog.c
@@ -130,7 +130,7 @@ slog_internal(struct server *s, log_level level,
 }
 
 /**
- * This wrapper around slog_internal that first checks the log level.
+ * Thin wrapper around slog_internal that first checks the log level.
  */
 void
 slog(struct server *s, log_level level,

--- a/src/slog.c
+++ b/src/slog.c
@@ -116,8 +116,9 @@ slog_internal(struct server *s, log_level level,
 	}
 
 	/* generate output line. */
+	char letter = (level == WEBDIS_TRACE ? 5 : c[level]);
 	line_sz = snprintf(line, sizeof(line),
-		"[%d] %s %c %s\n", (int)s->log.self, time_buf, c[level], msg);
+		"[%d] %s %c %s\n", (int)s->log.self, time_buf, letter, msg);
 
 	/* write to log and maybe flush to disk. */
 	ret = write(s->log.fd, line, line_sz);

--- a/src/slog.h
+++ b/src/slog.h
@@ -6,7 +6,8 @@ typedef enum {
 	WEBDIS_WARNING,
 	WEBDIS_NOTICE,
 	WEBDIS_INFO,
-	WEBDIS_DEBUG
+	WEBDIS_DEBUG,
+	WEBDIS_TRACE
 } log_level;
 
 typedef enum {
@@ -25,6 +26,9 @@ slog_init(struct server *s);
 
 void
 slog_fsync_init(struct server *s);
+
+int
+slog_enabled(struct server *s, log_level level);
 
 void slog(struct server *s, log_level level,
 		const char *body, size_t sz);

--- a/src/slog.h
+++ b/src/slog.h
@@ -7,7 +7,7 @@ typedef enum {
 	WEBDIS_NOTICE,
 	WEBDIS_INFO,
 	WEBDIS_DEBUG,
-	WEBDIS_TRACE
+	WEBDIS_TRACE = 8
 } log_level;
 
 typedef enum {

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -415,12 +415,14 @@ ws_reply(struct cmd *cmd, const char *p, size_t sz) {
 
 	/* send WS frame */
 	r = http_response_init(cmd->w, 0, NULL);
-	if (cmd_is_subscribe(cmd)) {
-		r->keep_alive = 1;
+	if (r == NULL) {
+		free(frame);
+		slog(cmd->w->s, WEBDIS_ERROR, "Failed response allocation in ws_reply", 0);
+		return -1;
 	}
 
-	if (r == NULL)
-		return -1;
+	/* mark as keep alive, otherwise we'll close the connection after the first reply */
+	r->keep_alive = 1;
 
 	r->out = frame;
 	r->out_sz = frame_sz;

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -117,12 +117,14 @@ ws_handshake_reply(struct http_client *c) {
 
 	/* need those headers */
 	if(!origin || !origin_sz || !host || !host_sz || !c->path || !c->path_sz) {
+		slog(c->s, WEBDIS_WARNING, "Missing headers for WS handshake", 0);
 		return -1;
 	}
 
 	memset(sha1_handshake, 0, sizeof(sha1_handshake));
 	if(ws_compute_handshake(c, &sha1_handshake[0], &handshake_sz) != 0) {
 		/* failed to compute handshake. */
+		slog(c->s, WEBDIS_WARNING, "Failed to compute handshake", 0);
 		return -1;
 	}
 

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -220,13 +220,12 @@ ws_execute(struct http_client *c, const char *frame, size_t frame_len) {
 }
 
 static struct ws_msg *
-ws_msg_new(struct server *s) {
-	slog(s, WEBDIS_TRACE, "ws_msg_new", 0);
+ws_msg_new() {
 	return calloc(1, sizeof(struct ws_msg));
 }
 
 static void
-ws_msg_add(struct server *s, struct ws_msg *m, const char *p, size_t psz, const unsigned char *mask) {
+ws_msg_add(struct ws_msg *m, const char *p, size_t psz, const unsigned char *mask) {
 
 	/* add data to frame */
 	size_t i;
@@ -237,35 +236,21 @@ ws_msg_add(struct server *s, struct ws_msg *m, const char *p, size_t psz, const 
 	for(i = 0; i < psz && mask; ++i) {
 		m->payload[m->payload_sz + i] = (unsigned char)p[i] ^ mask[i%4];
 	}
-	if (slog_enabled(s, WEBDIS_TRACE)) {
-		char format[] = "ws_msg_add: %lu bytes, mask_enabled=%c";
-		char mask_enabled = mask ? 'Y' : 'N';
-
-		size_t contents_sz = snprintf(NULL, 0, format, psz, mask_enabled);
-		char *contents_msg = calloc(contents_sz + 1, 1);
-		if (contents_msg) {
-			snprintf(contents_msg, contents_sz + 1, format, psz, mask_enabled);
-			slog(s, WEBDIS_TRACE, contents_msg, contents_sz);
-			free(contents_msg);
-		} else {
-			slog(s, WEBDIS_ERROR, "Failed allocation in ws_msg_add", 0);
-		}
-	}
 
 	/* save new size */
 	m->payload_sz += psz;
 }
 
 static void
-ws_msg_free(struct server *s, struct ws_msg **m) {
-	slog(s, WEBDIS_TRACE, "ws_msg_free", 0);
+ws_msg_free(struct ws_msg **m) {
+
 	free((*m)->payload);
 	free(*m);
 	*m = NULL;
 }
 
 static enum ws_state
-ws_parse_data(struct server *s, const char *frame, size_t sz, struct ws_msg **msg) {
+ws_parse_data(const char *frame, size_t sz, struct ws_msg **msg) {
 
 	int has_mask;
 	uint64_t len;
@@ -278,27 +263,9 @@ ws_parse_data(struct server *s, const char *frame, size_t sz, struct ws_msg **ms
 	}
 
 	has_mask = frame[1] & 0x80 ? 1:0;
-	if (slog_enabled(s, WEBDIS_TRACE)) {
-		char log_mask[]= "ws_parse_data: has_mask=?";
-		log_mask[sizeof(log_mask)-2] = has_mask ? 'Y' : 'N'; /* -1 for \0 and -1 again for last char */
-		slog(s, WEBDIS_TRACE, log_mask, sizeof(log_mask)-1);
-	}
 
 	/* get payload length */
 	len = frame[1] & 0x7f;	/* remove leftmost bit */
-
-	if (slog_enabled(s, WEBDIS_TRACE)) { /* log length */
-		char format[] = "ws_parse_data: payload length = %llu bytes";
-		size_t contents_sz = snprintf(NULL, 0, format, len);
-		char *contents_msg = calloc(contents_sz + 1, 1);
-		if (contents_msg) {
-			snprintf(contents_msg, contents_sz + 1, format, len);
-			slog(s, WEBDIS_TRACE, contents_msg, contents_sz);
-			free(contents_msg);
-		} else {
-			slog(s, WEBDIS_ERROR, "Failed allocation in ws_parse_data", 0);
-		}
-	}
 	if(len <= 125) { /* data starts right after the mask */
 		p = frame + 2 + (has_mask ? 4 : 0);
 		if(has_mask) memcpy(&mask, frame + 2, sizeof(mask));
@@ -322,15 +289,13 @@ ws_parse_data(struct server *s, const char *frame, size_t sz, struct ws_msg **ms
 	}
 
 	if(!*msg)
-		*msg = ws_msg_new(s);
-	ws_msg_add(s, *msg, p, len, has_mask ? mask : NULL);
+		*msg = ws_msg_new();
+	ws_msg_add(*msg, p, len, has_mask ? mask : NULL);
 	(*msg)->total_sz += len + (p - frame);
 
 	if(frame[0] & 0x80) { /* FIN bit set */
-		slog(s, WEBDIS_TRACE, "ws_parse_data: FIN bit set", 0);
 		return WS_MSG_COMPLETE;
 	} else {
-		slog(s, WEBDIS_TRACE, "ws_parse_data: FIN bit not set", 0);
 		return WS_READING;	/* need more data */
 	}
 }
@@ -344,43 +309,30 @@ ws_add_data(struct http_client *c) {
 
 	enum ws_state state;
 
-	state = ws_parse_data(c->s, c->buffer, c->sz, &c->frame);
+	state = ws_parse_data(c->buffer, c->sz, &c->frame);
 
 	while(state == WS_MSG_COMPLETE) {
 		int ret = ws_execute(c, c->frame->payload, c->frame->payload_sz);
-		if (slog_enabled(c->s, WEBDIS_TRACE)) {
-			char format[] = "ws_add_data: ws_execute(payload_sz=%lu) returned %d";
-
-			size_t contents_sz = snprintf(NULL, 0, format, c->frame->payload_sz, ret);
-			char *contents_msg = calloc(contents_sz + 1, 1);
-			if (contents_msg) {
-				snprintf(contents_msg, contents_sz + 1, format, c->frame->payload_sz, ret);
-				slog(c->s, WEBDIS_TRACE, contents_msg, contents_sz);
-				free(contents_msg);
-			} else {
-				slog(c->s, WEBDIS_ERROR, "Failed allocation in ws_add_data", 0);
-			}
-		}
 
 		/* remove frame from client buffer */
 		http_client_remove_data(c, c->frame->total_sz);
 
 		/* free frame and set back to NULL */
-		ws_msg_free(c->s, &c->frame);
+		ws_msg_free(&c->frame);
 
 		if(ret != 0) {
 			/* can't process frame. */
 			slog(c->s, WEBDIS_WARNING, "ws_add_data: ws_execute failed", 0);
 			return WS_ERROR;
 		}
-		slog(c->s, WEBDIS_TRACE, "ws_add_data: calling ws_parse_data again", 0);
-		state = ws_parse_data(c->s, c->buffer, c->sz, &c->frame);
+		state = ws_parse_data(c->buffer, c->sz, &c->frame);
 	}
 	return state;
 }
 
 int
 ws_reply(struct cmd *cmd, const char *p, size_t sz) {
+
 	char *frame = malloc(sz + 8); /* create frame by prepending header */
 	size_t frame_sz = 0;
 	struct http_response *r;
@@ -427,20 +379,6 @@ ws_reply(struct cmd *cmd, const char *p, size_t sz) {
 	r->out = frame;
 	r->out_sz = frame_sz;
 	r->sent = 0;
-
-	if (slog_enabled(cmd->w->s, WEBDIS_TRACE)) {
-		char format[] = "ws_reply: response is %lu bytes, frame is %lu";
-		size_t contents_sz = snprintf(NULL, 0, format, sz, frame_sz);
-		char *contents_msg = calloc(contents_sz + 1, 1);
-		if (contents_msg) {
-			snprintf(contents_msg, contents_sz + 1, format, sz, frame_sz);
-			slog(cmd->w->s, WEBDIS_TRACE, contents_msg, contents_sz);
-			free(contents_msg);
-		} else {
-			slog(cmd->w->s, WEBDIS_ERROR, "Failed allocation in ws_reply", 0);
-		}
-	}
-
 	http_schedule_write(cmd->fd, r);
 
 	return 0;

--- a/src/worker.c
+++ b/src/worker.c
@@ -35,7 +35,7 @@ worker_new(struct server *s) {
 
 void
 worker_can_read(int fd, short event, void *p) {
-
+	fprintf(stderr, "worker_can_read\n");
 	struct http_client *c = p;
 	int ret, nparsed;
 
@@ -87,9 +87,11 @@ worker_can_read(int fd, short event, void *p) {
 	}
 
 	if(c->broken) { /* terminate client */
+		fprintf(stderr, "c->broken: http_client_free()\n");
 		http_client_free(c);
 	} else {
 		/* start monitoring input again */
+		fprintf(stderr, "worker_monitor_input()\n");
 		worker_monitor_input(c);
 	}
 }

--- a/src/worker.c
+++ b/src/worker.c
@@ -35,13 +35,13 @@ worker_new(struct server *s) {
 
 void
 worker_can_read(int fd, short event, void *p) {
-	fprintf(stderr, "worker_can_read\n");
 	struct http_client *c = p;
 	int ret, nparsed;
 
 	(void)fd;
 	(void)event;
 
+	slog(c->w->s, WEBDIS_TRACE, "worker_can_read", 0);
 	ret = http_client_read(c);
 	if(ret <= 0) {
 		if((client_error_t)ret == CLIENT_DISCONNECTED) {
@@ -87,11 +87,11 @@ worker_can_read(int fd, short event, void *p) {
 	}
 
 	if(c->broken) { /* terminate client */
-		fprintf(stderr, "c->broken: http_client_free()\n");
+		slog(c->s, WEBDIS_TRACE, "worker_can_read: c->broken, calling http_client_free", 0);
 		http_client_free(c);
 	} else {
 		/* start monitoring input again */
-		fprintf(stderr, "worker_monitor_input()\n");
+		slog(c->s, WEBDIS_TRACE, "worker_can_read: calling worker_monitor_input again", 0);
 		worker_monitor_input(c);
 	}
 }

--- a/src/worker.c
+++ b/src/worker.c
@@ -35,6 +35,7 @@ worker_new(struct server *s) {
 
 void
 worker_can_read(int fd, short event, void *p) {
+
 	struct http_client *c = p;
 	int ret, nparsed;
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -41,7 +41,6 @@ worker_can_read(int fd, short event, void *p) {
 	(void)fd;
 	(void)event;
 
-	slog(c->w->s, WEBDIS_TRACE, "worker_can_read", 0);
 	ret = http_client_read(c);
 	if(ret <= 0) {
 		if((client_error_t)ret == CLIENT_DISCONNECTED) {
@@ -87,11 +86,9 @@ worker_can_read(int fd, short event, void *p) {
 	}
 
 	if(c->broken) { /* terminate client */
-		slog(c->s, WEBDIS_TRACE, "worker_can_read: c->broken, calling http_client_free", 0);
 		http_client_free(c);
 	} else {
 		/* start monitoring input again */
-		slog(c->s, WEBDIS_TRACE, "worker_can_read: calling worker_monitor_input again", 0);
 		worker_monitor_input(c);
 	}
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 OUT=websocket pubsub
 CFLAGS=-O3 -Wall -Wextra
-LDFLAGS=-levent -lpthread -lrt
+LDFLAGS=-levent -lpthread
 
 all: $(OUT) Makefile
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 OUT=websocket pubsub
-OBJS=../src/http-parser/http_parser.o
-CFLAGS=-Wall -Wextra -I../src/http-parser/
+OBJS=../src/http-parser/http_parser.o ../src/b64/cencode.o ../src/sha1/sha1.o
+CFLAGS=-Wall -Wextra -I../src -I../src/http-parser
 LDFLAGS=-levent -lpthread
 
 # if `make` is run with DEBUG=1, include debug symbols (same as in Makefile in root directory)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 OUT=websocket pubsub
 OBJS=../src/http-parser/http_parser.o ../src/b64/cencode.o ../src/sha1/sha1.o
 CFLAGS=-Wall -Wextra -I../src -I../src/http-parser
-LDFLAGS=-levent -lpthread
+LDFLAGS=-levent -lpthread -lm
 
 # if `make` is run with DEBUG=1, include debug symbols (same as in Makefile in root directory)
 DEBUG_FLAGS=

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,10 +1,25 @@
 OUT=websocket pubsub
-CFLAGS=-O0 -g -Wall -Wextra -I../src/http-parser/
-LDFLAGS=-g -levent -lpthread
+OBJS=../src/http-parser/http_parser.o
+CFLAGS=-Wall -Wextra -I../src/http-parser/
+LDFLAGS=-levent -lpthread
+
+# if `make` is run with DEBUG=1, include debug symbols (same as in Makefile in root directory)
+DEBUG_FLAGS=
+ifeq ($(DEBUG),1)
+	DEBUG_FLAGS += -O0
+	ifeq ($(shell cc -v 2>&1 | grep -cw 'gcc version'),1) # GCC used: add GDB debugging symbols
+		DEBUG_FLAGS += -ggdb3
+	else ifeq ($(shell gcc -v 2>&1 | grep -cw 'clang version'),1) # Clang used: add LLDB debugging symbols
+		DEBUG_FLAGS += -g3 -glldb
+	endif
+else
+	DEBUG_FLAGS += -O3
+endif
+CFLAGS += $(DEBUG_FLAGS)
 
 all: $(OUT) Makefile
 
-websocket: websocket.o ../src/http-parser/http_parser.o
+websocket: websocket.o $(OBJS)
 	$(CC) -o $@ $^ $(LDFLAGS)
 
 pubsub: pubsub.o
@@ -14,5 +29,5 @@ pubsub: pubsub.o
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 clean:
-	rm -f *.o $(OUT)
+	rm -f *.o $(OUT) $(OBJS)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,11 +1,11 @@
 OUT=websocket pubsub
-CFLAGS=-O3 -Wall -Wextra
-LDFLAGS=-levent -lpthread
+CFLAGS=-O0 -g -Wall -Wextra -I../src/http-parser/
+LDFLAGS=-g -levent -lpthread
 
 all: $(OUT) Makefile
 
-websocket: websocket.o
-	$(CC) -o $@ $< $(LDFLAGS)
+websocket: websocket.o ../src/http-parser/http_parser.o
+	$(CC) -o $@ $^ $(LDFLAGS)
 
 pubsub: pubsub.o
 	$(CC) -o $@ $< $(LDFLAGS)

--- a/tests/websocket.c
+++ b/tests/websocket.c
@@ -421,7 +421,7 @@ main(int argc, char *argv[]) {
 
     struct timespec t0, t1;
 
-    int messages_default = 100000;
+    int messages_default = 2500;
     int thread_count_default = 4;
     short port_default = 7379;
     char *host_default = "127.0.0.1";

--- a/tests/websocket.c
+++ b/tests/websocket.c
@@ -1,4 +1,4 @@
-/* http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-76 */
+/* https://datatracker.ietf.org/doc/html/rfc6455 */
 
 #include <stdlib.h>
 #define _GNU_SOURCE
@@ -15,312 +15,391 @@
 #include <event.h>
 
 struct host_info {
-	char *host;
-	short port;
+    char *host;
+    short port;
+};
+
+enum worker_state {
+    WS_INITIAL,
+    WS_SENT_HANDSHAKE,
+    WS_RECEIVED_RESPONSE,
+    WS_COMPLETE
 };
 
 /* worker_thread, with counter of remaining messages */
 struct worker_thread {
-	struct host_info *hi;
-	struct event_base *base;
+    struct host_info *hi;
+    struct event_base *base;
 
-	int msg_target;
-	int msg_received;
-	int msg_sent;
-	int byte_count;
-	pthread_t thread;
+    int msg_target;
+    int msg_received;
+    int msg_sent;
+    int byte_count;
+    pthread_t thread;
+    enum worker_state state;
 
-	struct evbuffer *buffer;
-	int got_header;
+    struct evbuffer *rbuffer;
+    int got_header;
 
-	int verbose;
-	struct event ev_w;
+    struct evbuffer *wbuffer;
+
+    int verbose;
+    int fd;
+    struct event ev_r;
+    struct event ev_w;
 };
+
+static void
+wait_for_possible_read(struct worker_thread *wt);
+static void
+wait_for_possible_write(struct worker_thread *wt);
 
 void
 process_message(struct worker_thread *wt, size_t sz) {
 
-	// printf("process_message\n");
-	if(wt->msg_received % 10000 == 0) {
-		printf("thread %u: %8d messages left (got %9d bytes so far).\n",
-			(unsigned int)wt->thread,
-			wt->msg_target - wt->msg_received, wt->byte_count);
-	}
-	wt->byte_count += sz;
+    // printf("process_message\n");
+    if(wt->msg_received % 10000 == 0) {
+        printf("thread %u: %8d messages left (got %9d bytes so far).\n",
+            (unsigned int)wt->thread,
+            wt->msg_target - wt->msg_received, wt->byte_count);
+    }
+    wt->byte_count += sz;
 
-	/* decrement read count, and stop receiving when we reach zero. */
-	wt->msg_received++;
-	if(wt->msg_received == wt->msg_target) {
-		event_base_loopexit(wt->base, NULL);
-	}
+    /* decrement read count, and stop receiving when we reach zero. */
+    wt->msg_received++;
+    if(wt->msg_received == wt->msg_target) {
+        event_base_loopexit(wt->base, NULL);
+    }
 }
 
+/**
+ * Called when we can write to the socket.
+ */
 void
-websocket_write(int fd, short event, void *ptr) {
-	int ret;
-	struct worker_thread *wt = ptr;
+websocket_can_write(int fd, short event, void *ptr) {
+    int ret;
+    struct worker_thread *wt = ptr;
+    printf("%s (wt=%p, fd=%d)\n", __func__, wt, fd);
 
-	if(event != EV_WRITE) {
-		return;
-	}
+    if(event != EV_WRITE) {
+        return;
+    }
+    switch (wt->state)
+    {
+    case WS_INITIAL: /* still sending initial HTTP request */
+        ret = evbuffer_write(wt->wbuffer, fd);
+        printf("evbuffer_write returned %d\n", ret);
+        printf("evbuffer_get_length returned %d\n", evbuffer_get_length(wt->wbuffer));
+        if (evbuffer_get_length(wt->wbuffer) != 0) { /* not all written */ 
+            wait_for_possible_write(wt);
+            return;
+        }
+        /* otherwise, we've sent the full request, time to read the response */
+        wt->state = WS_SENT_HANDSHAKE;
+        wait_for_possible_read(wt);
+        return;
 
-	char message[] = "\x00[\"SET\",\"key\",\"value\"]\xff\x00[\"GET\",\"key\"]\xff";
-	ret = write(fd, message, sizeof(message)-1);
-	if(ret != sizeof(message)-1) {
-		fprintf(stderr, "write on %d failed: %s\n", fd, strerror(errno));
-		close(fd);
-	}
+    default:
+        break;
+    }
+#if 0
+    char message[] = "\x00[\"SET\",\"key\",\"value\"]\xff\x00[\"GET\",\"key\"]\xff";
+    ret = write(fd, message, sizeof(message)-1);
+    if(ret != sizeof(message)-1) {
+        fprintf(stderr, "write on %d failed: %s\n", fd, strerror(errno));
+        close(fd);
+    }
 
-	wt->msg_sent += 2;
-	if(wt->msg_sent < wt->msg_target) {
-		event_set(&wt->ev_w, fd, EV_WRITE, websocket_write, wt);
-		event_base_set(wt->base, &wt->ev_w);
-		ret = event_add(&wt->ev_w, NULL);
-	}
+    wt->msg_sent += 2;
+    if(wt->msg_sent < wt->msg_target) {
+        event_set(&wt->ev_w, fd, EV_WRITE, websocket_can_write, wt);
+        event_base_set(wt->base, &wt->ev_w);
+        ret = event_add(&wt->ev_w, NULL);
+    }
+#endif
 }
 
 static void
-websocket_read(int fd, short event, void *ptr) {
-	char packet[2048], *pos;
-	int ret, success = 1;
+websocket_can_read(int fd, short event, void *ptr) {
+    char packet[2048], *pos;
+    int ret, success = 1;
 
-	struct worker_thread *wt = ptr;
+    struct worker_thread *wt = ptr;
+    printf("%s (wt=%p)\n", __func__, wt);
 
-	if(event != EV_READ) {
-		return;
-	}
+    if(event != EV_READ) {
+        return;
+    }
 
-	/* read message */
-	ret = read(fd, packet, sizeof(packet));
-	pos = packet;
-	if(ret > 0) {
-		char *data, *last;
-		int sz, msg_sz;
+    /* read message */
+    ret = evbuffer_read(wt->rbuffer, fd, 65536);
+    printf("evbuffer_read() returned %d\n", ret);
+    
 
-		if(wt->got_header == 0) { /* first response */
-			char *frame_start = strstr(packet, "MH"); /* end of the handshake */
-			if(frame_start == NULL) {
-				return; /* not yet */
-			} else { /* start monitoring possible writes */
-				printf("start monitoring possible writes\n");
-				evbuffer_add(wt->buffer, frame_start + 2, ret - (frame_start + 2 - packet));
+#if 0
+    pos = packet;
+    if(ret > 0) {
+        char *data, *last;
+        int sz, msg_sz;
 
-				wt->got_header = 1;
-				event_set(&wt->ev_w, fd, EV_WRITE,
-						websocket_write, wt);
-				event_base_set(wt->base, &wt->ev_w);
-				ret = event_add(&wt->ev_w, NULL);
-			}
-		} else {
-			/* we've had the header already, now bufffer data. */
-			evbuffer_add(wt->buffer, packet, ret);
-		}
+        if(wt->got_header == 0) { /* first response */
+            char *frame_start = strstr(packet, "MH"); /* end of the handshake */
+            if(frame_start == NULL) {
+                return; /* not yet */
+            } else { /* start monitoring possible writes */
+                printf("start monitoring possible writes\n");
+                evbuffer_add(wt->rbuffer, frame_start + 2, ret - (frame_start + 2 - packet));
 
-		while(1) {
-			data = (char*)EVBUFFER_DATA(wt->buffer);
-			sz = EVBUFFER_LENGTH(wt->buffer);
+                wt->got_header = 1;
+                event_set(&wt->ev_w, fd, EV_WRITE,
+                        websocket_can_write, wt);
+                event_base_set(wt->base, &wt->ev_w);
+                ret = event_add(&wt->ev_w, NULL);
+            }
+        } else {
+            /* we've had the header already, now bufffer data. */
+            evbuffer_add(wt->rbuffer, packet, ret);
+        }
 
-			if(sz == 0) { /* no data */
-				break;
-			}
-			if(*data != 0) { /* missing frame start */
-				success = 0;
-				break;
-			}
-			last = memchr(data, 0xff, sz); /* look for frame end */
-			if(!last) {
-				/* no end of frame in sight. */
-				break;
-			}
-			msg_sz = last - data - 1;
-			process_message(ptr, msg_sz); /* record packet */
+        while(1) {
+            data = (char*)EVBUFFER_DATA(wt->rbuffer);
+            sz = EVBUFFER_LENGTH(wt->rbuffer);
 
-			/* drain including frame delimiters (+2 bytes) */
-			evbuffer_drain(wt->buffer, msg_sz + 2); 
-		}
-	} else {
-		printf("ret=%d\n", ret);
-		success = 0;
-	}
-	if(success == 0) {
-		shutdown(fd, SHUT_RDWR);
-		close(fd);
-		event_base_loopexit(wt->base, NULL);
-	}
+            if(sz == 0) { /* no data */
+                break;
+            }
+            if(*data != 0) { /* missing frame start */
+                success = 0;
+                break;
+            }
+            last = memchr(data, 0xff, sz); /* look for frame end */
+            if(!last) {
+                /* no end of frame in sight. */
+                break;
+            }
+            msg_sz = last - data - 1;
+            process_message(ptr, msg_sz); /* record packet */
+
+            /* drain including frame delimiters (+2 bytes) */
+            evbuffer_drain(wt->rbuffer, msg_sz + 2); 
+        }
+    } else {
+        printf("ret=%d\n", ret);
+        success = 0;
+    }
+    if(success == 0) {
+        shutdown(fd, SHUT_RDWR);
+        close(fd);
+        event_base_loopexit(wt->base, NULL);
+    }
+    #endif
+}
+
+
+static void
+wait_for_possible_read(struct worker_thread *wt) {
+    printf("%s (wt=%p)\n", __func__, wt);
+    event_set(&wt->ev_r, wt->fd, EV_READ, websocket_can_read, wt);
+    event_base_set(wt->base, &wt->ev_r);
+    event_add(&wt->ev_r, NULL);
+}
+
+static void
+wait_for_possible_write(struct worker_thread *wt) {
+    printf("%s (wt=%p)\n", __func__, wt);
+    event_set(&wt->ev_r, wt->fd, EV_WRITE, websocket_can_write, wt);
+    event_base_set(wt->base, &wt->ev_r);
+    event_add(&wt->ev_r, NULL);
 }
 
 void*
 worker_main(void *ptr) {
 
-	char ws_template[] = "GET /.json HTTP/1.1\r\n"
-				"Host: %s:%d\r\n"
-				"Connection: Upgrade\r\n"
-				"Upgrade: WebSocket\r\n"
-				"Origin: http://%s:%d\r\n"
-				"Sec-WebSocket-Key1: 18x 6]8vM;54 *(5:  {   U1]8  z [  8\r\n"
-				"Sec-WebSocket-Key2: 1_ tx7X d  <  nw  334J702) 7]o}` 0\r\n"
-				"\r\n"
-				"Tm[K T2u";
+    char ws_template[] = "GET /.json HTTP/1.1\r\n"
+                "Host: %s:%d\r\n"
+                "Connection: Upgrade\r\n"
+                "Upgrade: WebSocket\r\n"
+                "Origin: http://%s:%d\r\n"
+                "Sec-WebSocket-Key: webdis-websocket-test-key\r\n"
+                "\r\n"
+                ;
 
-	struct worker_thread *wt = ptr;
+    struct worker_thread *wt = ptr;
 
-	int ret;
-	int fd;
-	struct sockaddr_in addr;
-	char *ws_handshake;
-	size_t ws_handshake_sz;
+    int ret;
+    int fd;
+    struct sockaddr_in addr;
+    char *ws_handshake;
+    size_t ws_handshake_sz;
 
-	/* connect socket */
-	fd = socket(AF_INET, SOCK_STREAM, 0);
-	addr.sin_family = AF_INET;
-	addr.sin_port = htons(wt->hi->port);
-	memset(&(addr.sin_addr), 0, sizeof(addr.sin_addr));
-	addr.sin_addr.s_addr = inet_addr(wt->hi->host);
+    /* connect socket */
+    fd = socket(AF_INET, SOCK_STREAM, 0);
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(wt->hi->port);
+    memset(&(addr.sin_addr), 0, sizeof(addr.sin_addr));
+    addr.sin_addr.s_addr = inet_addr(wt->hi->host);
 
-	ret = connect(fd, (struct sockaddr*)&addr, sizeof(struct sockaddr));
-	if(ret != 0) {
-		fprintf(stderr, "connect: ret=%d: %s\n", ret, strerror(errno));
-		return NULL;
-	}
+    ret = connect(fd, (struct sockaddr*)&addr, sizeof(struct sockaddr));
+    if(ret != 0) {
+        fprintf(stderr, "connect: ret=%d: %s\n", ret, strerror(errno));
+        return NULL;
+    }
 
-	/* initialize worker thread */
-	wt->base = event_base_new();
-	wt->buffer = evbuffer_new();
-	wt->byte_count = 0;
-	wt->got_header = 0;
+    /* initialize worker thread */
+    wt->fd = fd;
+    wt->base = event_base_new();
+    wt->rbuffer = evbuffer_new();
+    wt->wbuffer = evbuffer_new(); /* write buffer */
+    wt->byte_count = 0;
+    wt->got_header = 0;
 
-	/* send handshake */
-	ws_handshake_sz = sizeof(ws_handshake)
-		+ 2*strlen(wt->hi->host) + 500;
-	ws_handshake = calloc(ws_handshake_sz, 1);
-	ws_handshake_sz = (size_t)sprintf(ws_handshake, ws_template, 
-			wt->hi->host, wt->hi->port,
-			wt->hi->host, wt->hi->port);
-	ret = write(fd, ws_handshake, ws_handshake_sz);
+    /* build handshake buffer */
+    /*
+    ws_handshake_sz = sizeof(ws_handshake)
+        + 2*strlen(wt->hi->host) + 500;
+    ws_handshake = calloc(ws_handshake_sz, 1);
+    ws_handshake_sz = (size_t)sprintf(ws_handshake, ws_template, 
+            wt->hi->host, wt->hi->port,
+            wt->hi->host, wt->hi->port);
+    */
+    int added = evbuffer_add_printf(wt->wbuffer, ws_template, wt->hi->host, wt->hi->port,
+                                    wt->hi->host, wt->hi->port);
+    wait_for_possible_write(wt); /* request callback */
 
-	struct event ev_r;
-	event_set(&ev_r, fd, EV_READ | EV_PERSIST, websocket_read, wt);
-	event_base_set(wt->base, &ev_r);
-	event_add(&ev_r, NULL);
-
-	/* go! */
-	event_base_dispatch(wt->base);
-	event_base_free(wt->base);
-	free(ws_handshake);
-	return NULL;
+    /* go! */
+    event_base_dispatch(wt->base);
+    printf("event_base_dispatch returned\n");
+    event_base_free(wt->base);
+    free(ws_handshake);
+    return NULL;
 }
 
 void
 usage(const char* argv0, char *host_default, short port_default,
-		int thread_count_default, int messages_default) {
+        int thread_count_default, int messages_default) {
 
-	printf("Usage: %s [options]\n"
-		"Options are:\n"
-		"\t-h host\t\t(default = \"%s\")\n"
-		"\t-p port\t\t(default = %d)\n"
-		"\t-c threads\t(default = %d)\n"
-		"\t-n count\t(number of messages per thread, default = %d)\n"
-		"\t-v\t\t(verbose)\n",
-		argv0, host_default, (int)port_default,
-		thread_count_default, messages_default);
+    printf("Usage: %s [options]\n"
+        "Options are:\n"
+        "\t-h host\t\t(default = \"%s\")\n"
+        "\t-p port\t\t(default = %d)\n"
+        "\t-c threads\t(default = %d)\n"
+        "\t-n count\t(number of messages per thread, default = %d)\n"
+        "\t-v\t\t(verbose)\n",
+        argv0, host_default, (int)port_default,
+        thread_count_default, messages_default);
 }
 
 int
 main(int argc, char *argv[]) {
 
-	struct timespec t0, t1;
+    struct timespec t0, t1;
 
-	int messages_default = 100000;
-	int thread_count_default = 4;
-	short port_default = 7379;
-	char *host_default = "127.0.0.1";
+    int messages_default = 100000;
+    int thread_count_default = 4;
+    short port_default = 7379;
+    char *host_default = "127.0.0.1";
 
-	int msg_target = messages_default;
-	int thread_count = thread_count_default;
-	int i, opt;
-	char *colon;
-	double total = 0, total_bytes = 0;
-	int verbose = 0;
+    int msg_target = messages_default;
+    int thread_count = thread_count_default;
+    int i, opt;
+    char *colon;
+    double total = 0, total_bytes = 0;
+    int verbose = 0, single = 0;
 
-	struct host_info hi = {host_default, port_default};
+    struct host_info hi = {host_default, port_default};
 
-	struct worker_thread *workers;
+    struct worker_thread *workers;
 
-	/* getopt */
-	while ((opt = getopt(argc, argv, "h:p:c:n:v")) != -1) {
-		switch (opt) {
-			case 'h':
-				colon = strchr(optarg, ':');
-				if(!colon) {
-					size_t sz = strlen(optarg);
-					hi.host = calloc(1 + sz, 1);
-					strncpy(hi.host, optarg, sz);
-				} else {
-					hi.host = calloc(1+colon-optarg, 1);
-					strncpy(hi.host, optarg, colon-optarg);
-					hi.port = (short)atol(colon+1);
-				}
-				break;
+    /* getopt */
+    while ((opt = getopt(argc, argv, "h:p:c:n:vs")) != -1) {
+        switch (opt) {
+            case 'h':
+                colon = strchr(optarg, ':');
+                if(!colon) {
+                    size_t sz = strlen(optarg);
+                    hi.host = calloc(1 + sz, 1);
+                    strncpy(hi.host, optarg, sz);
+                } else {
+                    hi.host = calloc(1+colon-optarg, 1);
+                    strncpy(hi.host, optarg, colon-optarg);
+                    hi.port = (short)atol(colon+1);
+                }
+                break;
 
-			case 'p':
-				hi.port = (short)atol(optarg);
-				break;
+            case 'p':
+                hi.port = (short)atol(optarg);
+                break;
 
-			case 'c':
-				thread_count = atoi(optarg);
-				break;
+            case 'c':
+                thread_count = atoi(optarg);
+                break;
 
-			case 'n':
-				msg_target = atoi(optarg);
-				break;
+            case 'n':
+                msg_target = atoi(optarg);
+                break;
 
-			case 'v':
-				verbose = 1;
-				break;
-			default: /* '?' */
-				usage(argv[0], host_default, port_default,
-						thread_count_default,
-						messages_default);
-				exit(EXIT_FAILURE);
-		}
-	}
+            case 'v':
+                verbose = 1;
+                break;
 
-	/* run threads */
-	workers = calloc(sizeof(struct worker_thread), thread_count);
+            case 's':
+                single = 1;
+                thread_count = 1;
+                break;
+            default: /* '?' */
+                usage(argv[0], host_default, port_default,
+                        thread_count_default,
+                        messages_default);
+                exit(EXIT_FAILURE);
+        }
+    }
 
-	clock_gettime(CLOCK_MONOTONIC, &t0);
-	for(i = 0; i < thread_count; ++i) {
-		workers[i].msg_target = msg_target;
-		workers[i].hi = &hi;
-		workers[i].verbose = verbose;
+    /* run threads */
+    workers = calloc(sizeof(struct worker_thread), thread_count);
 
-		pthread_create(&workers[i].thread, NULL,
-				worker_main, &workers[i]);
-	}
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    if (single) {
+        printf("Single-threaded mode\n");
+        workers[0].msg_target = msg_target;
+        workers[0].hi = &hi;
+        workers[0].verbose = verbose;
+        workers[0].state = WS_INITIAL;
+        worker_main(&workers[0]);
+    } else {
+        for (i = 0; i < thread_count; ++i) {
+            workers[i].msg_target = msg_target;
+            workers[i].hi = &hi;
+            workers[i].verbose = verbose;
+            workers[i].state = WS_INITIAL;
 
-	/* wait for threads to finish */
-	for(i = 0; i < thread_count; ++i) {
-		pthread_join(workers[i].thread, NULL);
-		total += workers[i].msg_received;
-		total_bytes += workers[i].byte_count;
-	}
+            pthread_create(&workers[i].thread, NULL,
+                           worker_main, &workers[i]);
+        }
 
-	/* timing */
-	clock_gettime(CLOCK_MONOTONIC, &t1);
-	float mili0 = t0.tv_sec * 1000 + t0.tv_nsec / 1000000;
-	float mili1 = t1.tv_sec * 1000 + t1.tv_nsec / 1000000;
+        /* wait for threads to finish */
+        for (i = 0; i < thread_count; ++i) {
+            pthread_join(workers[i].thread, NULL);
+            total += workers[i].msg_received;
+            total_bytes += workers[i].byte_count;
+        }
+    }
 
-	if(total != 0) {
-		printf("Read %ld messages in %0.2f sec: %0.2f msg/sec (%d MB/sec, %d KB/sec)\n",
-			(long)total, 
-			(mili1-mili0)/1000.0,
-			1000*total/(mili1-mili0),
-			(int)(total_bytes / (1000*(mili1-mili0))),
-			(int)(total_bytes / (mili1-mili0)));
-		return EXIT_SUCCESS;
-	} else {
-		printf("No message was read.\n");
-		return EXIT_FAILURE;
-	}
+    /* timing */
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    float mili0 = t0.tv_sec * 1000 + t0.tv_nsec / 1000000;
+    float mili1 = t1.tv_sec * 1000 + t1.tv_nsec / 1000000;
+
+    if(total != 0) {
+        printf("Read %ld messages in %0.2f sec: %0.2f msg/sec (%d MB/sec, %d KB/sec)\n",
+            (long)total, 
+            (mili1-mili0)/1000.0,
+            1000*total/(mili1-mili0),
+            (int)(total_bytes / (1000*(mili1-mili0))),
+            (int)(total_bytes / (mili1-mili0)));
+        return EXIT_SUCCESS;
+    } else {
+        printf("No message was read.\n");
+        return EXIT_FAILURE;
+    }
 }
 

--- a/tests/websocket.c
+++ b/tests/websocket.c
@@ -9,6 +9,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <ctype.h>
+#include <getopt.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -40,6 +41,7 @@ struct worker_thread {
     int msg_received;
     int msg_sent;
     int byte_count;
+    int id;
     pthread_t thread;
     enum worker_state state;
 
@@ -55,34 +57,48 @@ struct worker_thread {
 
     http_parser parser;
     http_parser_settings settings;
+
+    int (*debug)(const char *fmt, ...);
 };
 
-void
-hex_dump(char *p, size_t sz) {
-#if DEBUG_LOGS
-    printf("hex dump of %p (%ld bytes)\n", p, sz);
-    for (char *cur = p; cur < p + sz; cur += 16) {
-        char letters[16] = {0};
-        int limit = (cur + 16) > p + sz ? (sz % 16) : 16;
-        printf("%08lx ", cur - p); /* address */
-        for (int i = 0; i < limit; i++) {
-            printf("%02x ", (unsigned int)(cur[i] & 0xff));
-            letters[i] = isprint(cur[i]) ? cur[i] : '.';
-        }
-        for (int i = limit; i < 16; i++) { /* pad on last line */
-            printf("   ");
-        }
-        printf(" %.*s\n", limit, letters);
-    }
-#endif
+int debug_noop(const char *fmt, ...) {
+    (void)fmt;
+    return 0;
+}
+
+int debug_verbose(const char *fmt, ...) {
+    int ret;
+    va_list vargs;
+    va_start(vargs, fmt);
+    ret = vfprintf(stderr, fmt, vargs);
+    va_end(vargs);
+    return ret;
 }
 
 void
-evbuffer_debug_dump(struct evbuffer *buffer) {
+hex_dump(struct worker_thread *wt, char *p, size_t sz) {
+    wt->debug("hex dump of %p (%ld bytes)\n", p, sz);
+    for (char *cur = p; cur < p + sz; cur += 16) {
+        char letters[16] = {0};
+        int limit = (cur + 16) > p + sz ? (sz % 16) : 16;
+        wt->debug("%08lx ", cur - p); /* address */
+        for (int i = 0; i < limit; i++) {
+            wt->debug("%02x ", (unsigned int)(cur[i] & 0xff));
+            letters[i] = isprint(cur[i]) ? cur[i] : '.';
+        }
+        for (int i = limit; i < 16; i++) { /* pad on last line */
+            wt->debug("   ");
+        }
+        wt->debug(" %.*s\n", limit, letters);
+    }
+}
+
+void
+evbuffer_debug_dump(struct worker_thread *wt, struct evbuffer *buffer) {
     size_t sz = evbuffer_get_length(buffer);
     char *data = malloc(sz);
     evbuffer_remove(buffer, data, sz);
-    hex_dump(data, sz);
+    hex_dump(wt, data, sz);
     evbuffer_prepend(buffer, data, sz);
     free(data);
 }
@@ -99,9 +115,9 @@ void
 process_message(struct worker_thread *wt, size_t sz) {
 
     // printf("process_message\n");
-    if(wt->msg_received % 10000 == 0) {
-        printf("thread %u: %8d messages left (got %9d bytes so far).\n",
-            (unsigned int)wt->thread,
+    if(wt->msg_received && wt->msg_received % 1000 == 0) {
+        printf("thread %d: %8d messages left (got %9d bytes so far).\n",
+            wt->id,
             wt->msg_target - wt->msg_received, wt->byte_count);
     }
     wt->byte_count += sz;
@@ -120,9 +136,7 @@ void
 websocket_can_write(int fd, short event, void *ptr) {
     int ret;
     struct worker_thread *wt = ptr;
-#if DEBUG_LOGS
-    printf("%s (wt=%p, fd=%d)\n", __func__, wt, fd);
-#endif
+    wt->debug("%s (wt=%p, fd=%d)\n", __func__, wt, fd);
 
     if(event != EV_WRITE) {
         return;
@@ -131,31 +145,23 @@ websocket_can_write(int fd, short event, void *ptr) {
     {
     case WS_INITIAL: { /* still sending initial HTTP request */
         ret = evbuffer_write(wt->wbuffer, fd);
-#if DEBUG_LOGS
-        printf("evbuffer_write returned %d\n", ret);
-        printf("evbuffer_get_length returned %d\n", evbuffer_get_length(wt->wbuffer));
-#endif
+        wt->debug("evbuffer_write returned %d\n", ret);
+        wt->debug("evbuffer_get_length returned %d\n", evbuffer_get_length(wt->wbuffer));
         if (evbuffer_get_length(wt->wbuffer) != 0) { /* not all written */
             wait_for_possible_write(wt);
             return;
         }
         /* otherwise, we've sent the full request, time to read the response */
         wt->state = WS_SENT_HANDSHAKE;
-#if DEBUG_LOGS
-        printf("state=WS_SENT_HANDSHAKE\n");
-#endif
+        wt->debug("state=WS_SENT_HANDSHAKE\n");
         wait_for_possible_read(wt);
         return;
     }
     case WS_RECEIVED_HANDSHAKE: { /* ready to send a frame */
-#if DEBUG_LOGS
-        printf("About to send data for WS frame, %lu in buffer\n", evbuffer_get_length(wt->wbuffer));
-#endif
+        wt->debug("About to send data for WS frame, %lu in buffer\n", evbuffer_get_length(wt->wbuffer));
         evbuffer_write(wt->wbuffer, fd);
         size_t write_remains = evbuffer_get_length(wt->wbuffer);
-#if DEBUG_LOGS
-        printf("Sent data for WS frame, still %lu left to write\n", write_remains);
-#endif
+        wt->debug("Sent data for WS frame, still %lu left to write\n", write_remains);
         if (write_remains == 0) { /* ready to read response */
             wt->state = WS_SENT_FRAME;
             wt->msg_sent++;
@@ -168,32 +174,14 @@ websocket_can_write(int fd, short event, void *ptr) {
     default:
         break;
     }
-#if 0
-    char message[] = "\x00[\"SET\",\"key\",\"value\"]\xff\x00[\"GET\",\"key\"]\xff";
-    ret = write(fd, message, sizeof(message)-1);
-    if(ret != sizeof(message)-1) {
-        fprintf(stderr, "write on %d failed: %s\n", fd, strerror(errno));
-        close(fd);
-    }
-
-    wt->msg_sent += 2;
-    if(wt->msg_sent < wt->msg_target) {
-        event_set(&wt->ev_w, fd, EV_WRITE, websocket_can_write, wt);
-        event_base_set(wt->base, &wt->ev_w);
-        ret = event_add(&wt->ev_w, NULL);
-    }
-#endif
 }
 
 static void
 websocket_can_read(int fd, short event, void *ptr) {
-    char packet[2048], *pos;
-    int ret, success = 1;
+    int ret;
 
     struct worker_thread *wt = ptr;
-#if DEBUG_LOGS
-    printf("%s (wt=%p)\n", __func__, wt);
-#endif
+    wt->debug("%s (wt=%p)\n", __func__, wt);
 
     if(event != EV_READ) {
         return;
@@ -201,14 +189,10 @@ websocket_can_read(int fd, short event, void *ptr) {
 
     /* read message */
     ret = evbuffer_read(wt->rbuffer, fd, 65536);
-#if DEBUG_LOGS
-    printf("evbuffer_read() returned %d; wt->state=%d. wt->rbuffer:\n", ret, wt->state);
-#endif
-    evbuffer_debug_dump(wt->rbuffer);
+    wt->debug("evbuffer_read() returned %d; wt->state=%d. wt->rbuffer:\n", ret, wt->state);
+    evbuffer_debug_dump(wt, wt->rbuffer);
     if (ret == 0) {
-#if DEBUG_LOGS
-        printf("We didn't read anything from the socket...\n");
-#endif
+        wt->debug("We didn't read anything from the socket...\n");
         wait_for_possible_read(wt);
         return;
     }
@@ -218,41 +202,30 @@ websocket_can_read(int fd, short event, void *ptr) {
         case WS_SENT_HANDSHAKE: { /* waiting for handshake response */
             size_t avail_sz = evbuffer_get_length(wt->rbuffer);
             char *tmp = calloc(avail_sz, 1);
-#if DEBUG_LOGS
-            printf("avail_sz from rbuffer = %lu\n", avail_sz);
-#endif
+            wt->debug("avail_sz from rbuffer = %lu\n", avail_sz);
             evbuffer_remove(wt->rbuffer, tmp, avail_sz); /* copy into `tmp` */
-#if DEBUG_LOGS
-            printf("Giving %lu bytes to http-parser\n", avail_sz);
-#endif
+            wt->debug("Giving %lu bytes to http-parser\n", avail_sz);
             int nparsed = http_parser_execute(&wt->parser, &wt->settings, tmp, avail_sz);
-#if DEBUG_LOGS
-            printf("http-parser returned %d\n", nparsed);
-#endif
+            wt->debug("http-parser returned %d\n", nparsed);
             if (nparsed != (int)avail_sz) { // put back what we didn't read
-#if DEBUG_LOGS
-                printf("re-attach (prepend) %lu bytes\n", avail_sz - nparsed);
-#endif
+                wt->debug("re-attach (prepend) %lu byte%c\n", avail_sz - nparsed,
+                          avail_sz - nparsed > 1 ? 's' : ' ');
                 evbuffer_prepend(wt->rbuffer, tmp + nparsed, avail_sz - nparsed);
             }
             free(tmp);
             if (wt->state == WS_SENT_HANDSHAKE &&  /* haven't encountered end of response yet */
                 wt->parser.upgrade && nparsed != (int)avail_sz) {
-#if DEBUG_LOGS
-                printf("UPGRADE *and* we have some data left\n");
-#endif
+                wt->debug("UPGRADE *and* we have some data left\n");
                 continue;
             } else if (wt->state == WS_RECEIVED_HANDSHAKE) { /* we have the full response */
                 evbuffer_drain(wt->rbuffer, evbuffer_get_length(wt->rbuffer));
             }
+            return;
         }
-        return;
 
         case WS_SENT_FRAME: { /* waiting for frame response */
-#if DEBUG_LOGS
-            printf("We're in WS_SENT_FRAME, just read a frame response. wt->rbuffer:\n");
-#endif
-            evbuffer_debug_dump(wt->rbuffer);
+            wt->debug("We're in WS_SENT_FRAME, just read a frame response. wt->rbuffer:\n");
+            evbuffer_debug_dump(wt, wt->rbuffer);
             uint8_t flag_opcodes, payload_len;
             if (evbuffer_get_length(wt->rbuffer) < 2) { /* not enough data */
                 wait_for_possible_read(wt);
@@ -264,116 +237,27 @@ websocket_can_read(int fd, short event, void *ptr) {
             process_message(wt, payload_len);
 
             if (evbuffer_get_length(wt->rbuffer) == 0) { /* consumed everything, let's write again */
-#if DEBUG_LOGS
-                printf("our turn to write again\n");
-#endif
+                wt->debug("our turn to write again\n");
                 wt->state = WS_RECEIVED_HANDSHAKE;
                 ws_enqueue_frame(wt);
                 return;
             } else {
-#if DEBUG_LOGS
-                printf("there's still data to consume\n");
-#endif
+                wt->debug("there's still data to consume\n");
                 continue;
             }
-#if 0
-            struct evbuffer_ptr sof = evbuffer_search(wt->rbuffer, "\x00", 1, NULL);
-            struct evbuffer_ptr eof = evbuffer_search(wt->rbuffer, "\xff", 1, NULL);
-            if (evbuffer_get_length(wt->rbuffer) >= 1 && sof.pos != 0) {
-                printf("ERROR: length=%lu, sof at pos %ld\n", evbuffer_get_length(wt->rbuffer), sof.pos);
-            }
-            if (eof.pos == -1) { /* not there yet */
-                printf("Couldn't find the end-of-frame marker, need to read more\n");
-                wait_for_possible_read(wt);
-            } else { /* we have a frame */
-                size_t bounded_frame_sz = eof.pos + 1;
-                char *bounded_frame = calloc(bounded_frame_sz, 1);
-                evbuffer_remove(wt->rbuffer, bounded_frame, bounded_frame_sz);
-                process_message(wt, bounded_frame_sz);
-                printf("Received frame (%lu bytes total):\n", bounded_frame_sz);
-                hex_dump(bounded_frame, bounded_frame_sz);
-                free(bounded_frame);
-                if (evbuffer_get_length(wt->rbuffer) > 0) { /* we may have more frames to process */
-                    continue;
-                } else { /* our turn to send a frame */
-                    printf("Add frame to write buffer\n");
-                    ws_enqueue_frame(wt);
-                }
-            }
-#endif
+            return;
         }
-        return;
 
         default:
             return;
         }
     }
-
-#if 0
-    pos = packet;
-    if(ret > 0) {
-        char *data, *last;
-        int sz, msg_sz;
-
-        if(wt->got_header == 0) { /* first response */
-            char *frame_start = strstr(packet, "MH"); /* end of the handshake */
-            if(frame_start == NULL) {
-                return; /* not yet */
-            } else { /* start monitoring possible writes */
-                printf("start monitoring possible writes\n");
-                evbuffer_add(wt->rbuffer, frame_start + 2, ret - (frame_start + 2 - packet));
-
-                wt->got_header = 1;
-                event_set(&wt->ev_w, fd, EV_WRITE,
-                        websocket_can_write, wt);
-                event_base_set(wt->base, &wt->ev_w);
-                ret = event_add(&wt->ev_w, NULL);
-            }
-        } else {
-            /* we've had the header already, now bufffer data. */
-            evbuffer_add(wt->rbuffer, packet, ret);
-        }
-
-        while(1) {
-            data = (char*)EVBUFFER_DATA(wt->rbuffer);
-            sz = EVBUFFER_LENGTH(wt->rbuffer);
-
-            if(sz == 0) { /* no data */
-                break;
-            }
-            if(*data != 0) { /* missing frame start */
-                success = 0;
-                break;
-            }
-            last = memchr(data, 0xff, sz); /* look for frame end */
-            if(!last) {
-                /* no end of frame in sight. */
-                break;
-            }
-            msg_sz = last - data - 1;
-            process_message(ptr, msg_sz); /* record packet */
-
-            /* drain including frame delimiters (+2 bytes) */
-            evbuffer_drain(wt->rbuffer, msg_sz + 2);
-        }
-    } else {
-        printf("ret=%d\n", ret);
-        success = 0;
-    }
-    if(success == 0) {
-        shutdown(fd, SHUT_RDWR);
-        close(fd);
-        event_base_loopexit(wt->base, NULL);
-    }
-#endif
 }
 
 
 static void
 wait_for_possible_read(struct worker_thread *wt) {
-#if DEBUG_LOGS
-    printf("%s (wt=%p)\n", __func__, wt);
-#endif
+    wt->debug("%s (wt=%p)\n", __func__, wt);
     event_set(&wt->ev_r, wt->fd, EV_READ, websocket_can_read, wt);
     event_base_set(wt->base, &wt->ev_r);
     event_add(&wt->ev_r, NULL);
@@ -381,9 +265,7 @@ wait_for_possible_read(struct worker_thread *wt) {
 
 static void
 wait_for_possible_write(struct worker_thread *wt) {
-#if DEBUG_LOGS
-    printf("%s (wt=%p)\n", __func__, wt);
-#endif
+    wt->debug("%s (wt=%p)\n", __func__, wt);
     event_set(&wt->ev_r, wt->fd, EV_WRITE, websocket_can_write, wt);
     event_base_set(wt->base, &wt->ev_r);
     event_add(&wt->ev_r, NULL);
@@ -393,9 +275,7 @@ static int
 ws_on_headers_complete(http_parser *p) {
     struct worker_thread *wt = p->data;
 
-#if DEBUG_LOGS
-    printf("%s (wt=%p)\n", __func__, wt);
-#endif
+    wt->debug("%s (wt=%p)\n", __func__, wt);
     // TODO
     return 0;
 }
@@ -409,7 +289,7 @@ ws_enqueue_frame_for_command(struct worker_thread *wt, char *cmd, size_t sz) {
     uint8_t len = (uint8_t)(sz); /* (1 << 7) | length. */
     len |= (1 << 7); /* set masking bit ON */
 
-    for (int i = 0; i < sz; i++) {
+    for (size_t i = 0; i < sz; i++) {
         cmd[i] = (cmd[i] ^ mask[i%4]) & 0xff;
     }
     /* 0x81 = 10000001b: FIN bit (only one message in the frame), text frame */
@@ -421,13 +301,6 @@ ws_enqueue_frame_for_command(struct worker_thread *wt, char *cmd, size_t sz) {
 
 static void
 ws_enqueue_frame(struct worker_thread *wt) {
-
-#if 0
-    char set_command[] = "[\"SET\",\"key\",\"value\"]";
-    ws_enqueue_frame_for_command(wt, set_command, sizeof(set_command) - 1);
-    char get_command[] = "[\"GET\",\"key\"]";
-    ws_enqueue_frame_for_command(wt, get_command, sizeof(get_command) - 1);
-#endif
     char ping_command[] = "[\"PING\"]";
     ws_enqueue_frame_for_command(wt, ping_command, sizeof(ping_command) - 1);
 
@@ -438,9 +311,7 @@ static int
 ws_on_message_complete(http_parser *p) {
     struct worker_thread *wt = p->data;
 
-#if DEBUG_LOGS
-    printf("%s (wt=%p)\n", __func__, wt);
-#endif
+    wt->debug("%s (wt=%p)\n", __func__, wt);
     // we've received the full HTTP response now, so we're ready to send frames
     wt->state = WS_RECEIVED_HANDSHAKE;
     ws_enqueue_frame(wt); /* add frame to buffer and register interest in writing */
@@ -464,8 +335,6 @@ worker_main(void *ptr) {
     int ret;
     int fd;
     struct sockaddr_in addr;
-    char *ws_handshake;
-    size_t ws_handshake_sz;
 
     /* connect socket */
     fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -495,24 +364,15 @@ worker_main(void *ptr) {
     http_parser_init(&wt->parser, HTTP_RESPONSE);
     wt->parser.data = wt;
 
-    /* build handshake buffer */
-    /*
-    ws_handshake_sz = sizeof(ws_handshake)
-        + 2*strlen(wt->hi->host) + 500;
-    ws_handshake = calloc(ws_handshake_sz, 1);
-    ws_handshake_sz = (size_t)sprintf(ws_handshake, ws_template,
-            wt->hi->host, wt->hi->port,
-            wt->hi->host, wt->hi->port);
-    */
-    int added = evbuffer_add_printf(wt->wbuffer, ws_template, wt->hi->host, wt->hi->port,
-                                    wt->hi->host, wt->hi->port);
+    /* add GET request to buffer */
+    evbuffer_add_printf(wt->wbuffer, ws_template, wt->hi->host, wt->hi->port,
+                        wt->hi->host, wt->hi->port);
     wait_for_possible_write(wt); /* request callback */
 
     /* go! */
     event_base_dispatch(wt->base);
-    printf("event_base_dispatch returned\n");
+    wt->debug("event_base_dispatch returned\n");
     event_base_free(wt->base);
-    // free(ws_handshake);
     return NULL;
 }
 
@@ -524,7 +384,7 @@ usage(const char* argv0, char *host_default, short port_default,
         "Options are:\n"
         "\t-h host\t\t(default = \"%s\")\n"
         "\t-p port\t\t(default = %d)\n"
-        "\t-c threads\t(default = %d)\n"
+        "\t-t threads\t(default = %d)\n"
         "\t-n count\t(number of messages per thread, default = %d)\n"
         "\t-v\t\t(verbose)\n",
         argv0, host_default, (int)port_default,
@@ -545,15 +405,24 @@ main(int argc, char *argv[]) {
     int thread_count = thread_count_default;
     int i, opt;
     char *colon;
-    double total = 0, total_bytes = 0;
-    int verbose = 0, single = 0;
+    long total = 0, total_bytes = 0;
+    int verbose = 0;
 
     struct host_info hi = {host_default, port_default};
 
     struct worker_thread *workers;
 
     /* getopt */
-    while ((opt = getopt(argc, argv, "h:p:c:n:vs")) != -1) {
+    struct option long_options[] = {
+        {"help", no_argument, NULL, '?'},
+        {"host", required_argument, NULL, 'h'},
+        {"port", required_argument, NULL, 'p'},
+        {"threads", required_argument, NULL, 't'},
+        {"messages", required_argument, NULL, 'n'},
+        {"verbose", no_argument, NULL, 'v'},
+        {0, 0, 0, 0}
+    };
+    while ((opt = getopt_long(argc, argv, "h:p:t:n:vs", long_options, NULL)) != -1) {
         switch (opt) {
             case 'h':
                 colon = strchr(optarg, ':');
@@ -572,7 +441,7 @@ main(int argc, char *argv[]) {
                 hi.port = (short)atol(optarg);
                 break;
 
-            case 'c':
+            case 't':
                 thread_count = atoi(optarg);
                 break;
 
@@ -584,10 +453,6 @@ main(int argc, char *argv[]) {
                 verbose = 1;
                 break;
 
-            case 's':
-                single = 1;
-                thread_count = 1;
-                break;
             default: /* '?' */
                 usage(argv[0], host_default, port_default,
                         thread_count_default,
@@ -600,20 +465,25 @@ main(int argc, char *argv[]) {
     workers = calloc(sizeof(struct worker_thread), thread_count);
 
     clock_gettime(CLOCK_MONOTONIC, &t0);
-    if (single) {
+    if (thread_count == 1) {
         printf("Single-threaded mode\n");
+        workers[0].id = 0;
         workers[0].msg_target = msg_target;
         workers[0].hi = &hi;
         workers[0].verbose = verbose;
         workers[0].state = WS_INITIAL;
+        workers[0].debug = verbose ? debug_verbose : debug_noop;
         worker_main(&workers[0]);
+        total = workers[0].msg_received;
+        total_bytes = workers[0].byte_count;
     } else {
         for (i = 0; i < thread_count; ++i) {
+            workers[i].id = i;
             workers[i].msg_target = msg_target;
             workers[i].hi = &hi;
             workers[i].verbose = verbose;
             workers[i].state = WS_INITIAL;
-
+            workers[i].debug = verbose ? debug_verbose : debug_noop;
             pthread_create(&workers[i].thread, NULL,
                            worker_main, &workers[i]);
         }
@@ -632,12 +502,13 @@ main(int argc, char *argv[]) {
     float mili1 = t1.tv_sec * 1000 + t1.tv_nsec / 1000000;
 
     if(total != 0) {
-        printf("Read %ld messages in %0.2f sec: %0.2f msg/sec (%d MB/sec, %d KB/sec)\n",
-            (long)total,
+        double kb_per_sec = ((double)total_bytes / (double)(mili1-mili0)) / 1.024;
+        printf("Read %ld messages (%ld bytes) in %0.2f sec: %0.2f msg/sec (%0.2f KB/sec)\n",
+            total,
+            total_bytes,
             (mili1-mili0)/1000.0,
-            1000*total/(mili1-mili0),
-            (int)(total_bytes / (1000*(mili1-mili0))),
-            (int)(total_bytes / (mili1-mili0)));
+            1000*((double)total)/(mili1-mili0),
+            kb_per_sec);
         return EXIT_SUCCESS;
     } else {
         printf("No message was read.\n");

--- a/tests/websocket.c
+++ b/tests/websocket.c
@@ -313,7 +313,6 @@ ws_on_header_field(http_parser *p, const char *at, size_t length) {
 	}
 	wt->debug("%s appended header name data: currently [%.*s]\n", __func__,
 		  (int)wt->cur_hdr_key_len, wt->cur_hdr_key);
-	// wt->cur_header_is_ws_resp = (strncasecmp(at, "Sec-WebSocket-Accept", 20) == 0) ? 1 : 0;
 
 	wt->hdr_last_cb_was_name = 1;
 	return 0;
@@ -419,7 +418,7 @@ ws_on_message_complete(http_parser *p) {
 	struct worker_thread *wt = p->data;
 
 	wt->debug("%s (wt=%p), upgrade=%d\n", __func__, wt, p->upgrade);
-	// we've received the full HTTP response now, so we're ready to send frames
+	/* we've received the full HTTP response now, so we're ready to send frames */
 	wt->state = WS_RECEIVED_HANDSHAKE;
 	ws_enqueue_frame(wt); /* add frame to buffer and register interest in writing */
 	return 0;

--- a/tests/websocket.c
+++ b/tests/websocket.c
@@ -17,95 +17,98 @@
 #include <event.h>
 #include <http_parser.h>
 
-#define DEBUG_LOGS 0
-
-struct host_info {
-    char *host;
-    short port;
+struct host_info{
+	char *host;
+	short port;
 };
 
 enum worker_state {
-    WS_INITIAL,
-    WS_SENT_HANDSHAKE,
-    WS_RECEIVED_HANDSHAKE,
-    WS_SENT_FRAME,
-    WS_COMPLETE
+	WS_INITIAL,
+	WS_SENT_HANDSHAKE,
+	WS_RECEIVED_HANDSHAKE,
+	WS_SENT_FRAME,
+	WS_COMPLETE
 };
 
 /* worker_thread, with counter of remaining messages */
 struct worker_thread {
-    struct host_info *hi;
-    struct event_base *base;
+	struct host_info *hi;
+	struct event_base *base;
 
-    int msg_target;
-    int msg_received;
-    int msg_sent;
-    int byte_count;
-    int id;
-    pthread_t thread;
-    enum worker_state state;
-    int timeout_seconds;
+	int msg_target;
+	int msg_received;
+	int msg_sent;
+	int byte_count;
+	int id;
+	pthread_t thread;
+	enum worker_state state;
+	int timeout_seconds;
 
-    struct evbuffer *rbuffer;
-    int got_header;
+	struct evbuffer *rbuffer;
+	int got_header;
 
-    struct evbuffer *wbuffer;
+	struct evbuffer *wbuffer;
 
-    int verbose;
-    int fd;
-    struct event ev_r;
-    struct event ev_w;
+	int verbose;
+	int fd;
+	struct event ev_r;
+	struct event ev_w;
 
-    http_parser parser;
-    http_parser_settings settings;
+	http_parser parser;
+	http_parser_settings settings;
 
-    int (*debug)(const char *fmt, ...);
+	int (*debug)(const char *fmt, ...);
 };
 
 int debug_noop(const char *fmt, ...) {
-    (void)fmt;
-    return 0;
+	(void)fmt;
+	return 0;
 }
 
 int debug_verbose(const char *fmt, ...) {
-    int ret;
-    va_list vargs;
-    va_start(vargs, fmt);
-    ret = vfprintf(stderr, fmt, vargs);
-    va_end(vargs);
-    return ret;
+	int ret;
+	va_list vargs;
+	va_start(vargs, fmt);
+	ret = vfprintf(stderr, fmt, vargs);
+	va_end(vargs);
+	return ret;
 }
 
 void
 hex_dump(struct worker_thread *wt, char *p, size_t sz) {
-    wt->debug("hex dump of %p (%ld bytes)\n", p, sz);
-    for (char *cur = p; cur < p + sz; cur += 16) {
-        char letters[16] = {0};
-        int limit = (cur + 16) > p + sz ? (sz % 16) : 16;
-        wt->debug("%08lx ", cur - p); /* address */
-        for (int i = 0; i < limit; i++) {
-            wt->debug("%02x ", (unsigned int)(cur[i] & 0xff));
-            letters[i] = isprint(cur[i]) ? cur[i] : '.';
-        }
-        for (int i = limit; i < 16; i++) { /* pad on last line */
-            wt->debug("   ");
-        }
-        wt->debug(" %.*s\n", limit, letters);
-    }
+	wt->debug("hex dump of %p (%ld bytes)\n", p, sz);
+	for (char *cur = p; cur < p + sz; cur += 16) {
+		char letters[16] = {0};
+		int limit = (cur + 16) > p + sz ? (sz % 16) : 16;
+		wt->debug("%08lx ", cur - p); /* address */
+		for (int i = 0; i < limit; i++) {
+			wt->debug("%02x ", (unsigned int)(cur[i] & 0xff));
+			letters[i] = isprint(cur[i]) ? cur[i] : '.';
+		}
+		for (int i = limit; i < 16; i++) { /* pad on last line */
+			wt->debug("   "); /* 3 spaces for "%02x " */
+		}
+		wt->debug(" %.*s\n", limit, letters);
+	}
 }
 
 void
 evbuffer_debug_dump(struct worker_thread *wt, struct evbuffer *buffer) {
-    size_t sz = evbuffer_get_length(buffer);
-    char *data = malloc(sz);
-    evbuffer_remove(buffer, data, sz);
-    hex_dump(wt, data, sz);
-    evbuffer_prepend(buffer, data, sz);
-    free(data);
+	size_t sz = evbuffer_get_length(buffer);
+	char *data = malloc(sz);
+	if (!data) {
+		fprintf(stderr, "failed to allocate %ld bytes\n", sz);
+		return;
+	}
+	evbuffer_remove(buffer, data, sz);
+	hex_dump(wt, data, sz);
+	evbuffer_prepend(buffer, data, sz);
+	free(data);
 }
 
 static void
 wait_for_possible_read(struct worker_thread *wt);
+
 static void
 wait_for_possible_write(struct worker_thread *wt);
 
@@ -114,22 +117,20 @@ ws_enqueue_frame(struct worker_thread *wt);
 
 void
 process_message(struct worker_thread *wt, size_t sz) {
+	if (wt->msg_received && wt->msg_received % 1000 == 0) {
+		printf("thread %d: %8d messages left (got %9d bytes so far).\n",
+		       wt->id,
+		       wt->msg_target - wt->msg_received, wt->byte_count);
+	}
+	wt->byte_count += sz;
 
-    // printf("process_message\n");
-    if(wt->msg_received && wt->msg_received % 1000 == 0) {
-        printf("thread %d: %8d messages left (got %9d bytes so far).\n",
-            wt->id,
-            wt->msg_target - wt->msg_received, wt->byte_count);
-    }
-    wt->byte_count += sz;
-
-    /* decrement read count, and stop receiving when we reach zero. */
-    wt->msg_received++;
-    if(wt->msg_received == wt->msg_target) {
-        wt->debug("%s: thread %d has received all %d messages it expected\n",
-            __func__, wt->id, wt->msg_received);
-        event_base_loopexit(wt->base, NULL);
-    }
+	/* decrement read count, and stop receiving when we reach zero. */
+	wt->msg_received++;
+	if (wt->msg_received == wt->msg_target) {
+		wt->debug("%s: thread %d has received all %d messages it expected\n",
+			  __func__, wt->id, wt->msg_received);
+		event_base_loopexit(wt->base, NULL);
+	}
 }
 
 /**
@@ -137,408 +138,396 @@ process_message(struct worker_thread *wt, size_t sz) {
  */
 void
 websocket_can_write(int fd, short event, void *ptr) {
-    int ret;
-    struct worker_thread *wt = ptr;
-    wt->debug("%s (wt=%p, fd=%d)\n", __func__, wt, fd);
+	int ret;
+	struct worker_thread *wt = ptr;
+	wt->debug("%s (wt=%p, fd=%d)\n", __func__, wt, fd);
 
-    if(event != EV_WRITE) {
-        return;
-    }
-    switch (wt->state)
-    {
-    case WS_INITIAL: { /* still sending initial HTTP request */
-        ret = evbuffer_write(wt->wbuffer, fd);
-        wt->debug("evbuffer_write returned %d\n", ret);
-        wt->debug("evbuffer_get_length returned %d\n", evbuffer_get_length(wt->wbuffer));
-        if (evbuffer_get_length(wt->wbuffer) != 0) { /* not all written */
-            wait_for_possible_write(wt);
-            return;
-        }
-        /* otherwise, we've sent the full request, time to read the response */
-        wt->state = WS_SENT_HANDSHAKE;
-        wt->debug("state=WS_SENT_HANDSHAKE\n");
-        wait_for_possible_read(wt);
-        return;
-    }
-    case WS_RECEIVED_HANDSHAKE: { /* ready to send a frame */
-        wt->debug("About to send data for WS frame, %lu in buffer\n", evbuffer_get_length(wt->wbuffer));
-        evbuffer_write(wt->wbuffer, fd);
-        size_t write_remains = evbuffer_get_length(wt->wbuffer);
-        wt->debug("Sent data for WS frame, still %lu left to write\n", write_remains);
-        if (write_remains == 0) { /* ready to read response */
-            wt->state = WS_SENT_FRAME;
-            wt->msg_sent++;
-            wait_for_possible_read(wt);
-        } else { /* not finished writing */
-            wait_for_possible_write(wt);
-        }
-        return;
-    }
-    default:
-        break;
-    }
+	switch (wt->state) {
+	case WS_INITIAL: { /* still sending initial HTTP request */
+		ret = evbuffer_write(wt->wbuffer, fd);
+		wt->debug("evbuffer_write returned %d\n", ret);
+		wt->debug("evbuffer_get_length returned %d\n", evbuffer_get_length(wt->wbuffer));
+		if (evbuffer_get_length(wt->wbuffer) != 0) { /* not all written */
+			wait_for_possible_write(wt);
+			return;
+		}
+		/* otherwise, we've sent the full request, time to read the response */
+		wt->state = WS_SENT_HANDSHAKE;
+		wt->debug("state=WS_SENT_HANDSHAKE\n");
+		wait_for_possible_read(wt);
+		return;
+	}
+	case WS_RECEIVED_HANDSHAKE: { /* ready to send a frame */
+		wt->debug("About to send data for WS frame, %lu in buffer\n", evbuffer_get_length(wt->wbuffer));
+		evbuffer_write(wt->wbuffer, fd);
+		size_t write_remains = evbuffer_get_length(wt->wbuffer);
+		wt->debug("Sent data for WS frame, still %lu left to write\n", write_remains);
+		if (write_remains == 0) { /* ready to read response */
+			wt->state = WS_SENT_FRAME;
+			wt->msg_sent++;
+			wait_for_possible_read(wt);
+		} else { /* not finished writing */
+			wait_for_possible_write(wt);
+		}
+		return;
+	}
+	default:
+		break;
+	}
 }
 
 static void
 websocket_can_read(int fd, short event, void *ptr) {
-    int ret;
+	int ret;
 
-    struct worker_thread *wt = ptr;
-    wt->debug("%s (wt=%p)\n", __func__, wt);
+	struct worker_thread *wt = ptr;
+	wt->debug("%s (wt=%p)\n", __func__, wt);
 
-    if(event != EV_READ) {
-        return;
-    }
+	/* read message */
+	ret = evbuffer_read(wt->rbuffer, fd, 65536);
+	wt->debug("evbuffer_read() returned %d; wt->state=%d. wt->rbuffer:\n", ret, wt->state);
+	evbuffer_debug_dump(wt, wt->rbuffer);
+	if (ret == 0) {
+		wt->debug("We didn't read anything from the socket...\n");
+		event_base_loopexit(wt->base, NULL);
+		return;
+	}
 
-    /* read message */
-    ret = evbuffer_read(wt->rbuffer, fd, 65536);
-    wt->debug("evbuffer_read() returned %d; wt->state=%d. wt->rbuffer:\n", ret, wt->state);
-    evbuffer_debug_dump(wt, wt->rbuffer);
-    if (ret == 0) {
-        wt->debug("We didn't read anything from the socket...\n");
-        return;
-    }
+	while (1) {
+		switch (wt->state) {
+		case WS_SENT_HANDSHAKE: { /* waiting for handshake response */
+			size_t avail_sz = evbuffer_get_length(wt->rbuffer);
+			char *tmp = calloc(avail_sz, 1);
+			wt->debug("avail_sz from rbuffer = %lu\n", avail_sz);
+			evbuffer_remove(wt->rbuffer, tmp, avail_sz); /* copy into `tmp` */
+			wt->debug("Giving %lu bytes to http-parser\n", avail_sz);
+			int nparsed = http_parser_execute(&wt->parser, &wt->settings, tmp, avail_sz);
+			wt->debug("http-parser returned %d\n", nparsed);
+			if (nparsed != (int)avail_sz) { // put back what we didn't read
+				wt->debug("re-attach (prepend) %lu byte%c\n", avail_sz - nparsed,
+					  avail_sz - nparsed > 1 ? 's' : ' ');
+				evbuffer_prepend(wt->rbuffer, tmp + nparsed, avail_sz - nparsed);
+			}
+			free(tmp);
+			if (wt->state == WS_SENT_HANDSHAKE && /* haven't encountered end of response yet */
+			    wt->parser.upgrade && nparsed != (int)avail_sz) {
+				wt->debug("UPGRADE *and* we have some data left\n");
+				continue;
+			} else if (wt->state == WS_RECEIVED_HANDSHAKE) { /* we have the full response */
+				evbuffer_drain(wt->rbuffer, evbuffer_get_length(wt->rbuffer));
+			}
+			return;
+		}
 
-    while(1) {
-        switch (wt->state) {
-        case WS_SENT_HANDSHAKE: { /* waiting for handshake response */
-            size_t avail_sz = evbuffer_get_length(wt->rbuffer);
-            char *tmp = calloc(avail_sz, 1);
-            wt->debug("avail_sz from rbuffer = %lu\n", avail_sz);
-            evbuffer_remove(wt->rbuffer, tmp, avail_sz); /* copy into `tmp` */
-            wt->debug("Giving %lu bytes to http-parser\n", avail_sz);
-            int nparsed = http_parser_execute(&wt->parser, &wt->settings, tmp, avail_sz);
-            wt->debug("http-parser returned %d\n", nparsed);
-            if (nparsed != (int)avail_sz) { // put back what we didn't read
-                wt->debug("re-attach (prepend) %lu byte%c\n", avail_sz - nparsed,
-                          avail_sz - nparsed > 1 ? 's' : ' ');
-                evbuffer_prepend(wt->rbuffer, tmp + nparsed, avail_sz - nparsed);
-            }
-            free(tmp);
-            if (wt->state == WS_SENT_HANDSHAKE &&  /* haven't encountered end of response yet */
-                wt->parser.upgrade && nparsed != (int)avail_sz) {
-                wt->debug("UPGRADE *and* we have some data left\n");
-                continue;
-            } else if (wt->state == WS_RECEIVED_HANDSHAKE) { /* we have the full response */
-                evbuffer_drain(wt->rbuffer, evbuffer_get_length(wt->rbuffer));
-            }
-            return;
-        }
+		case WS_SENT_FRAME: { /* waiting for frame response */
+			wt->debug("We're in WS_SENT_FRAME, just read a frame response. wt->rbuffer:\n");
+			evbuffer_debug_dump(wt, wt->rbuffer);
+			uint8_t flag_opcodes, payload_len;
+			if (evbuffer_get_length(wt->rbuffer) < 2) { /* not enough data */
+				wait_for_possible_read(wt);
+				return;
+			}
+			evbuffer_remove(wt->rbuffer, &flag_opcodes, 1);	  /* remove flags & opcode */
+			evbuffer_remove(wt->rbuffer, &payload_len, 1);	  /* remove length */
+			evbuffer_drain(wt->rbuffer, (size_t)payload_len); /* remove payload itself */
+			process_message(wt, payload_len);
 
-        case WS_SENT_FRAME: { /* waiting for frame response */
-            wt->debug("We're in WS_SENT_FRAME, just read a frame response. wt->rbuffer:\n");
-            evbuffer_debug_dump(wt, wt->rbuffer);
-            uint8_t flag_opcodes, payload_len;
-            if (evbuffer_get_length(wt->rbuffer) < 2) { /* not enough data */
-                wait_for_possible_read(wt);
-                return;
-            }
-            evbuffer_remove(wt->rbuffer, &flag_opcodes, 1); /* remove flags & opcode */
-            evbuffer_remove(wt->rbuffer, &payload_len, 1);  /* remove length */
-            evbuffer_drain(wt->rbuffer, (size_t)payload_len); /* remove payload itself */
-            process_message(wt, payload_len);
+			if (evbuffer_get_length(wt->rbuffer) == 0) { /* consumed everything */
+				if (wt->msg_received < wt->msg_target) { /* let's write again */
+					wt->debug("our turn to write again\n");
+					wt->state = WS_RECEIVED_HANDSHAKE;
+					ws_enqueue_frame(wt);
+				} /* otherwise, we're done */
+				return;
+			} else {
+				wt->debug("there's still data to consume\n");
+				continue;
+			}
+			return;
+		}
 
-            if (evbuffer_get_length(wt->rbuffer) == 0) { /* consumed everything */
-                if (wt->msg_received < wt->msg_target) { /* let's write again */
-                    wt->debug("our turn to write again\n");
-                    wt->state = WS_RECEIVED_HANDSHAKE;
-                    ws_enqueue_frame(wt);
-                } /* otherwise, we're done */
-                return;
-            } else {
-                wt->debug("there's still data to consume\n");
-                continue;
-            }
-            return;
-        }
-
-        default:
-            return;
-        }
-    }
+		default:
+			return;
+		}
+	}
 }
 
 
 static void
 wait_for_possible_read(struct worker_thread *wt) {
-    wt->debug("%s (wt=%p)\n", __func__, wt);
-    event_set(&wt->ev_r, wt->fd, EV_READ, websocket_can_read, wt);
-    event_base_set(wt->base, &wt->ev_r);
-    event_add(&wt->ev_r, NULL);
+	wt->debug("%s (wt=%p)\n", __func__, wt);
+	event_set(&wt->ev_r, wt->fd, EV_READ, websocket_can_read, wt);
+	event_base_set(wt->base, &wt->ev_r);
+	event_add(&wt->ev_r, NULL);
 }
 
 static void
 wait_for_possible_write(struct worker_thread *wt) {
-    wt->debug("%s (wt=%p)\n", __func__, wt);
-    event_set(&wt->ev_r, wt->fd, EV_WRITE, websocket_can_write, wt);
-    event_base_set(wt->base, &wt->ev_r);
-    event_add(&wt->ev_r, NULL);
+	wt->debug("%s (wt=%p)\n", __func__, wt);
+	event_set(&wt->ev_r, wt->fd, EV_WRITE, websocket_can_write, wt);
+	event_base_set(wt->base, &wt->ev_r);
+	event_add(&wt->ev_r, NULL);
 }
 
 static int
 ws_on_headers_complete(http_parser *p) {
-    struct worker_thread *wt = p->data;
-
-    wt->debug("%s (wt=%p)\n", __func__, wt);
-    // TODO
-    return 0;
+	struct worker_thread *wt = p->data;
+	wt->debug("%s (wt=%p)\n", __func__, wt);
+	return 0;
 }
 
 static void
 ws_enqueue_frame_for_command(struct worker_thread *wt, char *cmd, size_t sz) {
-    unsigned char mask[4];
-    for (int i = 0; i < 4; i++) {
-        mask[i] = rand() & 0xff;
-    }
-    uint8_t len = (uint8_t)(sz); /* (1 << 7) | length. */
-    len |= (1 << 7); /* set masking bit ON */
+	unsigned char mask[4];
+	for (int i = 0; i < 4; i++) {
+		mask[i] = rand() & 0xff;
+	}
+	uint8_t len = (uint8_t)(sz); /* (1 << 7) | length. */
+	len |= (1 << 7);	     /* set masking bit ON */
 
-    for (size_t i = 0; i < sz; i++) {
-        cmd[i] = (cmd[i] ^ mask[i%4]) & 0xff;
-    }
-    /* 0x81 = 10000001b: FIN bit (only one message in the frame), text frame */
-    evbuffer_add(wt->wbuffer, "\x81", 1);
-    evbuffer_add(wt->wbuffer, &len, 1);
-    evbuffer_add(wt->wbuffer, mask, 4);
-    evbuffer_add(wt->wbuffer, cmd, sz);
+	for (size_t i = 0; i < sz; i++) {
+		cmd[i] = (cmd[i] ^ mask[i % 4]) & 0xff;
+	}
+	/* 0x81 = 10000001b: FIN bit (only one message in the frame), text frame */
+	evbuffer_add(wt->wbuffer, "\x81", 1);
+	evbuffer_add(wt->wbuffer, &len, 1);
+	evbuffer_add(wt->wbuffer, mask, 4);
+	evbuffer_add(wt->wbuffer, cmd, sz);
 }
 
 static void
 ws_enqueue_frame(struct worker_thread *wt) {
-    char ping_command[] = "[\"PING\"]";
-    ws_enqueue_frame_for_command(wt, ping_command, sizeof(ping_command) - 1);
+	char ping_command[] = "[\"PING\"]";
+	ws_enqueue_frame_for_command(wt, ping_command, sizeof(ping_command) - 1);
 
-    wait_for_possible_write(wt);
+	wait_for_possible_write(wt);
 }
 
 static int
 ws_on_message_complete(http_parser *p) {
-    struct worker_thread *wt = p->data;
+	struct worker_thread *wt = p->data;
 
-    wt->debug("%s (wt=%p)\n", __func__, wt);
-    // we've received the full HTTP response now, so we're ready to send frames
-    wt->state = WS_RECEIVED_HANDSHAKE;
-    ws_enqueue_frame(wt); /* add frame to buffer and register interest in writing */
-    return 0;
+	wt->debug("%s (wt=%p)\n", __func__, wt);
+	// we've received the full HTTP response now, so we're ready to send frames
+	wt->state = WS_RECEIVED_HANDSHAKE;
+	ws_enqueue_frame(wt); /* add frame to buffer and register interest in writing */
+	return 0;
 }
 
 static void
 ws_on_timeout(evutil_socket_t fd, short event, void *arg) {
-    struct worker_thread *wt = arg;
-    (void) fd;
-    (void) event;
+	struct worker_thread *wt = arg;
+	(void)fd;
+	(void)event;
 
-    fprintf(stderr, "Time has run out! (thread %d)\n", wt->id);
-    event_base_loopbreak(wt->base); /* break out of event loop */
+	fprintf(stderr, "Time has run out! (thread %d)\n", wt->id);
+	event_base_loopbreak(wt->base); /* break out of event loop */
 }
 
 void*
 worker_main(void *ptr) {
 
-    char ws_template[] = "GET /.json HTTP/1.1\r\n"
-                "Host: %s:%d\r\n"
-                "Connection: Upgrade\r\n"
-                "Upgrade: WebSocket\r\n"
-                "Origin: http://%s:%d\r\n"
-                "Sec-WebSocket-Key: webdis-websocket-test-key\r\n"
-                "\r\n"
-                ;
+	char ws_template[] = "GET /.json HTTP/1.1\r\n"
+			     "Host: %s:%d\r\n"
+			     "Connection: Upgrade\r\n"
+			     "Upgrade: WebSocket\r\n"
+			     "Origin: http://%s:%d\r\n"
+			     "Sec-WebSocket-Key: webdis-websocket-test-key\r\n"
+			     "\r\n";
 
-    struct worker_thread *wt = ptr;
+	struct worker_thread *wt = ptr;
 
-    int ret;
-    int fd;
-    struct sockaddr_in addr;
-    struct timeval timeout_tv;
-    struct event *timeout_ev;
+	int ret;
+	int fd;
+	struct sockaddr_in addr;
+	struct timeval timeout_tv;
+	struct event *timeout_ev;
 
-    /* connect socket */
-    fd = socket(AF_INET, SOCK_STREAM, 0);
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(wt->hi->port);
-    memset(&(addr.sin_addr), 0, sizeof(addr.sin_addr));
-    addr.sin_addr.s_addr = inet_addr(wt->hi->host);
+	/* connect socket */
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(wt->hi->port);
+	memset(&(addr.sin_addr), 0, sizeof(addr.sin_addr));
+	addr.sin_addr.s_addr = inet_addr(wt->hi->host);
 
-    ret = connect(fd, (struct sockaddr*)&addr, sizeof(struct sockaddr));
-    if(ret != 0) {
-        fprintf(stderr, "connect: ret=%d: %s\n", ret, strerror(errno));
-        return NULL;
-    }
+	ret = connect(fd, (struct sockaddr *)&addr, sizeof(struct sockaddr));
+	if (ret != 0) {
+		fprintf(stderr, "connect: ret=%d: %s\n", ret, strerror(errno));
+		return NULL;
+	}
 
-    /* initialize worker thread */
-    wt->fd = fd;
-    wt->base = event_base_new();
-    wt->rbuffer = evbuffer_new();
-    wt->wbuffer = evbuffer_new(); /* write buffer */
-    wt->byte_count = 0;
-    wt->got_header = 0;
+	/* initialize worker thread */
+	wt->fd = fd;
+	wt->base = event_base_new();
+	wt->rbuffer = evbuffer_new();
+	wt->wbuffer = evbuffer_new(); /* write buffer */
+	wt->byte_count = 0;
+	wt->got_header = 0;
 
-    /* add timeout, if set */
-    if (wt->timeout_seconds > 0) {
-        timeout_tv.tv_sec = wt->timeout_seconds;
-        timeout_tv.tv_usec = 0;
-        timeout_ev = event_new(wt->base, -1, EV_TIMEOUT, ws_on_timeout, wt);
-        event_add(timeout_ev, &timeout_tv);
-    }
+	/* add timeout, if set */
+	if (wt->timeout_seconds > 0) {
+		timeout_tv.tv_sec = wt->timeout_seconds;
+		timeout_tv.tv_usec = 0;
+		timeout_ev = event_new(wt->base, -1, EV_TIMEOUT, ws_on_timeout, wt);
+		event_add(timeout_ev, &timeout_tv);
+	}
 
-    /* initialize HTTP parser, to parse the server response */
-    memset(&wt->settings, 0, sizeof(http_parser_settings));
-    wt->settings.on_headers_complete = ws_on_headers_complete;
-    wt->settings.on_message_complete = ws_on_message_complete;
-    http_parser_init(&wt->parser, HTTP_RESPONSE);
-    wt->parser.data = wt;
+	/* initialize HTTP parser, to parse the server response */
+	memset(&wt->settings, 0, sizeof(http_parser_settings));
+	wt->settings.on_headers_complete = ws_on_headers_complete;
+	wt->settings.on_message_complete = ws_on_message_complete;
+	http_parser_init(&wt->parser, HTTP_RESPONSE);
+	wt->parser.data = wt;
 
-    /* add GET request to buffer */
-    evbuffer_add_printf(wt->wbuffer, ws_template, wt->hi->host, wt->hi->port,
-                        wt->hi->host, wt->hi->port);
-    wait_for_possible_write(wt); /* request callback */
+	/* add GET request to buffer */
+	evbuffer_add_printf(wt->wbuffer, ws_template, wt->hi->host, wt->hi->port,
+			    wt->hi->host, wt->hi->port);
+	wait_for_possible_write(wt); /* request callback */
 
-    /* go! */
-    event_base_dispatch(wt->base);
-    wt->debug("event_base_dispatch returned\n");
-    event_base_free(wt->base);
-    return NULL;
+	/* go! */
+	event_base_dispatch(wt->base);
+	wt->debug("event_base_dispatch returned\n");
+	event_base_free(wt->base);
+	return NULL;
 }
 
-void
-usage(const char* argv0, char *host_default, short port_default,
-        int thread_count_default, int messages_default) {
+void usage(const char *argv0, char *host_default, short port_default,
+	   int thread_count_default, int messages_default) {
 
-    printf("Usage: %s [options]\n"
-        "Options are:\n"
-        "\t[--host|-h] HOST\t(default = \"%s\")\n"
-        "\t[--port|-p] PORT\t(default = %d)\n"
-        "\t[--clients|-c] THREADS\t(default = %d)\n"
-        "\t[--messages|-n] COUNT\t(number of messages per thread, default = %d)\n"
-        "\t[--max-time|-t] SECONDS\t(max time to give to the run, default = unlimited)\n"
-        "\t[--verbose|-v]\t\t(extremely verbose output)\n",
-        argv0, host_default, (int)port_default,
-        thread_count_default, messages_default);
+	printf("Usage: %s [options]\n"
+	       "Options are:\n"
+	       "\t[--host|-h] HOST\t(default = \"%s\")\n"
+	       "\t[--port|-p] PORT\t(default = %d)\n"
+	       "\t[--clients|-c] THREADS\t(default = %d)\n"
+	       "\t[--messages|-n] COUNT\t(number of messages per thread, default = %d)\n"
+	       "\t[--max-time|-t] SECONDS\t(max time to give to the run, default = unlimited)\n"
+	       "\t[--verbose|-v]\t\t(extremely verbose output)\n",
+	       argv0, host_default, (int)port_default,
+	       thread_count_default, messages_default);
 }
 
 int
 main(int argc, char *argv[]) {
 
-    struct timespec t0, t1;
+	struct timespec t0, t1;
 
-    int messages_default = 2500;
-    int thread_count_default = 4;
-    short port_default = 7379;
-    char *host_default = "127.0.0.1";
+	int messages_default = 2500;
+	int thread_count_default = 4;
+	short port_default = 7379;
+	char *host_default = "127.0.0.1";
 
-    int msg_target = messages_default;
-    int thread_count = thread_count_default;
-    int i, opt;
-    char *colon;
-    long total = 0, total_bytes = 0;
-    int verbose = 0;
-    int timeout_seconds = -1;
+	int msg_target = messages_default;
+	int thread_count = thread_count_default;
+	int i, opt;
+	char *colon;
+	long total = 0, total_bytes = 0;
+	int verbose = 0;
+	int timeout_seconds = -1;
 
-    struct host_info hi = {host_default, port_default};
+	struct host_info hi = {host_default, port_default};
 
-    struct worker_thread *workers;
+	struct worker_thread *workers;
 
-    /* getopt */
-    struct option long_options[] = {
-        {"help", no_argument, NULL, '?'},
-        {"host", required_argument, NULL, 'h'},
-        {"port", required_argument, NULL, 'p'},
-        {"clients", required_argument, NULL, 'c'},
-        {"messages", required_argument, NULL, 'n'},
-        {"max-time", required_argument, NULL, 't'},
-        {"verbose", no_argument, NULL, 'v'},
-        {0, 0, 0, 0}
-    };
-    while ((opt = getopt_long(argc, argv, "h:p:c:n:t:vs", long_options, NULL)) != -1) {
-        switch (opt) {
-            case 'h':
-                colon = strchr(optarg, ':');
-                if(!colon) {
-                    size_t sz = strlen(optarg);
-                    hi.host = calloc(1 + sz, 1);
-                    strncpy(hi.host, optarg, sz);
-                } else {
-                    hi.host = calloc(1+colon-optarg, 1);
-                    strncpy(hi.host, optarg, colon-optarg);
-                    hi.port = (short)atol(colon+1);
-                }
-                break;
+	/* getopt */
+	struct option long_options[] = {
+	    {"help", no_argument, NULL, '?'},
+	    {"host", required_argument, NULL, 'h'},
+	    {"port", required_argument, NULL, 'p'},
+	    {"clients", required_argument, NULL, 'c'},
+	    {"messages", required_argument, NULL, 'n'},
+	    {"max-time", required_argument, NULL, 't'},
+	    {"verbose", no_argument, NULL, 'v'},
+	    {0, 0, 0, 0}};
+	while ((opt = getopt_long(argc, argv, "h:p:c:n:t:vs", long_options, NULL)) != -1) {
+		switch (opt) {
+		case 'h':
+			colon = strchr(optarg, ':');
+			if (!colon) {
+				size_t sz = strlen(optarg);
+				hi.host = calloc(1 + sz, 1);
+				strncpy(hi.host, optarg, sz);
+			} else {
+				hi.host = calloc(1 + colon - optarg, 1);
+				strncpy(hi.host, optarg, colon - optarg);
+				hi.port = (short)atol(colon + 1);
+			}
+			break;
 
-            case 'p':
-                hi.port = (short)atol(optarg);
-                break;
+		case 'p':
+			hi.port = (short)atol(optarg);
+			break;
 
-            case 'c':
-                thread_count = atoi(optarg);
-                break;
+		case 'c':
+			thread_count = atoi(optarg);
+			break;
 
-            case 'n':
-                msg_target = atoi(optarg);
-                break;
+		case 'n':
+			msg_target = atoi(optarg);
+			break;
 
-            case 't':
-                timeout_seconds = atoi(optarg);
-                break;
+		case 't':
+			timeout_seconds = atoi(optarg);
+			break;
 
-            case 'v':
-                verbose = 1;
-                break;
+		case 'v':
+			verbose = 1;
+			break;
 
-            default: /* '?' */
-                usage(argv[0], host_default, port_default,
-                        thread_count_default,
-                        messages_default);
-                exit(EXIT_SUCCESS);
-        }
-    }
+		default: /* '?' */
+			usage(argv[0], host_default, port_default,
+			      thread_count_default,
+			      messages_default);
+			exit(EXIT_SUCCESS);
+		}
+	}
 
-    /* run threads */
-    workers = calloc(sizeof(struct worker_thread), thread_count);
+	/* run threads */
+	workers = calloc(sizeof(struct worker_thread), thread_count);
 
-    clock_gettime(CLOCK_MONOTONIC, &t0);
-    for (i = 0; i < thread_count; ++i) {
-        workers[i].id = i;
-        workers[i].msg_target = msg_target;
-        workers[i].hi = &hi;
-        workers[i].verbose = verbose;
-        workers[i].state = WS_INITIAL;
-        workers[i].debug = verbose ? debug_verbose : debug_noop;
-        workers[i].timeout_seconds = timeout_seconds;
-        if (thread_count == 1) {
-            printf("Single-threaded mode\n");
-            worker_main(&workers[0]);
-        } else { /* create threads */
-            pthread_create(&workers[i].thread, NULL,
-                           worker_main, &workers[i]);
-        }
-    }
+	clock_gettime(CLOCK_MONOTONIC, &t0);
+	for (i = 0; i < thread_count; ++i) {
+		workers[i].id = i;
+		workers[i].msg_target = msg_target;
+		workers[i].hi = &hi;
+		workers[i].verbose = verbose;
+		workers[i].state = WS_INITIAL;
+		workers[i].debug = verbose ? debug_verbose : debug_noop;
+		workers[i].timeout_seconds = timeout_seconds;
+		if (thread_count == 1) {
+			printf("Single-threaded mode\n");
+			worker_main(&workers[0]);
+		} else { /* create threads */
+			pthread_create(&workers[i].thread, NULL,
+				       worker_main, &workers[i]);
+		}
+	}
 
-    /* wait for threads to finish */
-    for (i = 0; i < thread_count; ++i) {
-        if (thread_count > 1) {
-            pthread_join(workers[i].thread, NULL);
-        }
-        total += workers[i].msg_received;
-        total_bytes += workers[i].byte_count;
-    }
+	/* wait for threads to finish */
+	for (i = 0; i < thread_count; ++i) {
+		if (thread_count > 1) {
+			pthread_join(workers[i].thread, NULL);
+		}
+		total += workers[i].msg_received;
+		total_bytes += workers[i].byte_count;
+	}
 
-    /* timing */
-    clock_gettime(CLOCK_MONOTONIC, &t1);
-    float mili0 = t0.tv_sec * 1000 + t0.tv_nsec / 1000000;
-    float mili1 = t1.tv_sec * 1000 + t1.tv_nsec / 1000000;
+	/* timing */
+	clock_gettime(CLOCK_MONOTONIC, &t1);
+	float mili0 = t0.tv_sec * 1000 + t0.tv_nsec / 1000000;
+	float mili1 = t1.tv_sec * 1000 + t1.tv_nsec / 1000000;
 
-    if(total != 0) {
-        double kb_per_sec = ((double)total_bytes / (double)(mili1-mili0)) / 1.024;
-        printf("Read %ld messages (%ld bytes) in %0.2f sec: %0.2f msg/sec (%0.2f KB/sec)\n",
-            total,
-            total_bytes,
-            (mili1-mili0)/1000.0,
-            1000*((double)total)/(mili1-mili0),
-            kb_per_sec);
-        return (total == thread_count * msg_target ? EXIT_SUCCESS : EXIT_FAILURE);
-    } else {
-        printf("No message was read.\n");
-        return EXIT_FAILURE;
-    }
+	if (total != 0) {
+		double kb_per_sec = ((double)total_bytes / (double)(mili1 - mili0)) / 1.024;
+		printf("Read %ld messages (%ld bytes) in %0.2f sec: %0.2f msg/sec (%0.2f KB/sec)\n",
+		       total,
+		       total_bytes,
+		       (mili1 - mili0) / 1000.0,
+		       1000 * ((double)total) / (mili1 - mili0),
+		       kb_per_sec);
+		return (total == thread_count * msg_target ? EXIT_SUCCESS : EXIT_FAILURE);
+	} else {
+		printf("No message was read.\n");
+		return EXIT_FAILURE;
+	}
 }
 

--- a/tests/websocket.c
+++ b/tests/websocket.c
@@ -500,20 +500,13 @@ main(int argc, char *argv[]) {
 		workers[i].state = WS_INITIAL;
 		workers[i].debug = verbose ? debug_verbose : debug_noop;
 		workers[i].timeout_seconds = timeout_seconds;
-		if (thread_count == 1) {
-			printf("Single-threaded mode\n");
-			worker_main(&workers[0]);
-		} else { /* create threads */
-			pthread_create(&workers[i].thread, NULL,
-				       worker_main, &workers[i]);
-		}
+		pthread_create(&workers[i].thread, NULL,
+			       worker_main, &workers[i]);
 	}
 
 	/* wait for threads to finish */
 	for (i = 0; i < thread_count; ++i) {
-		if (thread_count > 1) {
-			pthread_join(workers[i].thread, NULL);
-		}
+		pthread_join(workers[i].thread, NULL);
 		total += workers[i].msg_received;
 		total_bytes += workers[i].byte_count;
 	}

--- a/tests/websocket.c
+++ b/tests/websocket.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <getopt.h>
+#include <sys/ioctl.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -339,6 +340,7 @@ worker_main(void *ptr) {
 
 	int ret;
 	int fd;
+	int int_one = 1;
 	struct sockaddr_in addr;
 	struct timeval timeout_tv;
 	struct event *timeout_ev;
@@ -353,6 +355,11 @@ worker_main(void *ptr) {
 	ret = connect(fd, (struct sockaddr *)&addr, sizeof(struct sockaddr));
 	if (ret != 0) {
 		fprintf(stderr, "connect: ret=%d: %s\n", ret, strerror(errno));
+		return NULL;
+	}
+	ret = ioctl(fd, FIONBIO, &int_one);
+	if (ret != 0) {
+		fprintf(stderr, "ioctl: ret=%d: %s\n", ret, strerror(errno));
 		return NULL;
 	}
 

--- a/tests/websocket.html
+++ b/tests/websocket.html
@@ -3,150 +3,215 @@
 	<head>
 		<title>WebSocket example</title>
 		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="stylesheet" href="https://unpkg.com/purecss@2.0.6/build/pure-min.css" integrity="sha384-Uu6IeWbM+gzNVXJcM9XV3SohHtmWE+3VGi496jvgX1jyvDTXfdK+rfZc8C1Aehk5" crossorigin="anonymous">
 		<style type="text/css">
-
-			body {
-				width: 800px;
-				margin: auto;
-			}
-
-			header {
-				font-size: 36pt;
-				width: 100%;
+			h1, h3 {
 				text-align: center;
-				margin-bottom: 1em;
-				color: #541F14;
 			}
 
-			section.proto {
-				float: left;
-				/*background-color: #f8f8f8;*/
-			}
-
-			section#json {
-				width: 380px;
-				margin-right: 20px;
-			}
-
-			section#raw {
-				width: 380px;
-				padding-left: 16px;
-				border-left: 4px solid #626266;
-			}
-
-			div.desc {
-				margin: 0px;
-			}
 			pre.sent, pre.received {
 				margin-top: 0px;
 				border-radius: 4px;
 				padding: 5px;
 			}
+
 			pre.sent {
-				border: 1px solid #938172;
+				border: 1px solid #4b63cc;
 				background-color: white;
 			}
+
 			pre.received {
-				border: 1px solid #CC9E61;
+				border: 1px solid #4db96d;
 				text-align: right;
 			}
 
+			.ws-state {
+				font-weight: bold;
+				line-height: 18px;
+				vertical-align: middle;
+			}
+
+			div.log {
+				font-size: 13pt;
+			}
 		</style>
 	</head>
 
 	<body>
-		<header>Webdis with HTML5 WebSockets</header>
+		<div class="pure-g">
+		<h1 class="pure-u-1">Webdis with HTML5 WebSockets</h1>
+		</div>
 
-		<section class="proto" id="json">
-			<h3>JSON</h3>
-			<div class="log" id="json-log">
-				Connecting...
+		<div class="pure-g">
+			<div class="pure-u-1-8"></div>
+			<div class="pure-u-1-3">
+				<h3>JSON</h3>
+				<form class="pure-form">
+					<fieldset>
+						<div class="pure-g">
+							<div class="pure-u-2-3"><label class="ws-state pure-u-23-24" id="json-state">State: Disconnected</label></div>
+							<div class="pure-u-1-3"><button type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-connect">Connect</button></div>
+						</div>
+					</fieldset>
+				</form>
+				<form class="pure-form">
+					<fieldset>
+						<div class="pure-g">
+							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="json-set-key" value="hello" /></div>
+							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="value" id="json-set-value" value="world" /></div>
+							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-set">SET</button></div>
+						</div>
+					</fieldset>
+				</form>
+				<form class="pure-form">
+					<fieldset>
+						<div class="pure-g">
+							<div class="pure-u-1-3">&nbsp;</div>
+							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="json-get-key" value="hello" /></div>
+							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-get">GET</button></div>
+						</div>
+					</fieldset>
+				</form>
+
+				<div class="pure-g">
+					<div class="pure-u-2-3">&nbsp;</div>
+					<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-clear">Clear logs</button></div>
+					<div class="log pure-u-1-1" id="json-log">
+					</div>
+				</div>
 			</div>
-		</section>
-		<section class="proto" id="raw">
-			<h3>Raw</h3>
-			<div class="log" id="raw-log">
-				Connecting...
+
+			<!-- spacer -->
+			<div class="pure-u-1-12"></div>
+
+			<div class="pure-u-1-3">
+				<h3>Raw</h3>
+				<form class="pure-form">
+					<fieldset>
+						<div class="pure-g">
+							<div class="pure-u-2-3"><label class="ws-state pure-u-23-24" id="raw-state">State: Disconnected</label></div>
+							<div class="pure-u-1-3"><button type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-connect">Connect</button></div>
+						</div>
+					</fieldset>
+				</form>
+				<form class="pure-form">
+					<fieldset>
+						<div class="pure-g">
+							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="raw-set-key" value="hello" /></div>
+							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="value" id="raw-set-value" value="world" /></div>
+							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-set">SET</button></div>
+						</div>
+					</fieldset>
+				</form>
+				<form class="pure-form">
+					<fieldset>
+						<div class="pure-g">
+							<div class="pure-u-1-3">&nbsp;</div>
+							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="raw-get-key" value="hello" /></div>
+							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-get">GET</button></div>
+						</div>
+					</fieldset>
+				</form>
+
+				<div class="pure-g">
+					<div class="pure-u-2-3">&nbsp;</div>
+					<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-clear">Clear logs</button></div>
+					<div class="log pure-u-1-1" id="raw-log">
+					</div>
+				</div>
 			</div>
-		</section>
 
+			<div class="pure-u-1-8"></div>
+		</div>
 
-		<script type="text/javascript">
+<script type="text/javascript">
 
 $ = function(id) {return document.getElementById(id);};
-var host = "127.0.0.1";
-var port = 7379;
+const host = "127.0.0.1";
+const port = 7379;
 
-function log(id, dir, msg) {
+class Client {
+	constructor(type, getSerializer, setSerializer) {
+		this.type = type;
+		this.getSerializer = getSerializer;
+		this.setSerializer = setSerializer;
+		this.ws = null;
 
-	var desc = document.createElement("div");
-	desc.setAttribute("class", "desc");
-	desc.innerHTML = dir;
-	$(id).appendChild(desc);
+		$(`${this.type}-btn-connect`).addEventListener('click', event => {
+			event.preventDefault();
+			console.log('Connecting...');
+			this.ws = new WebSocket(`ws://${ host }:${ port }/.${ this.type }`);
+			this.ws.onopen = event => {
+				console.log('Connected');
+				this.setConnectedState(true);
+			};
 
-	var e = document.createElement("pre");
-	e.setAttribute("class", dir);
-	e.innerHTML = msg;
-	$(id).appendChild(e);
+			// log received messages
+			this.ws.onmessage = messageEvent => {
+				this.log("received", messageEvent.data);
+			};
+
+			this.ws.onclose = event => {
+				$(`${this.type}-btn-connect`).disabled = false;
+				this.setConnectedState(false);
+			};
+		});
+
+		$(`${this.type}-btn-set`).addEventListener('click', event => {
+			event.preventDefault();
+			const serialized = this.setSerializer($(`${this.type}-set-key`).value, $(`${this.type}-set-value`).value);
+			this.log("sent", serialized);
+			this.ws.send(serialized);
+		});
+
+		$(`${this.type}-btn-get`).addEventListener('click', event => {
+			event.preventDefault();
+			const serialized = this.getSerializer($(`${this.type}-set-key`).value);
+			this.log("sent", serialized);
+			this.ws.send(serialized);
+		});
+
+		$(`${this.type}-btn-clear`).addEventListener('click', event => {
+			event.preventDefault();
+			$(`${this.type}-log`).innerText = "";
+		});
+	}
+
+	setConnectedState(connected) {
+		$(`${this.type}-btn-connect`).disabled = connected;
+		$(`${this.type}-set-key`).disabled = !connected;
+		$(`${this.type}-set-value`).disabled = !connected;
+		$(`${this.type}-btn-set`).disabled = !connected;
+		$(`${this.type}-get-key`).disabled = !connected;
+		$(`${this.type}-btn-get`).disabled = !connected;
+		$(`${this.type}-btn-clear`).disabled = !connected;
+		$(`${this.type}-state`).innerText = `State: ${connected ? 'Connected' : 'Disconnected'}`;
+	}
+
+	log(dir, msg) {
+		const id = `${this.type}-log`;
+
+		const description = document.createElement("div");
+		description.innerHTML = dir;
+		$(id).appendChild(description);
+
+		const contents = document.createElement("pre");
+		contents.setAttribute("class", dir);
+		contents.innerHTML = msg;
+		$(id).appendChild(contents);
+	}
 }
 
-function testJSON() {
+addEventListener("DOMContentLoaded", () => {
+	const jsonClient = new Client('json',
+		(key) => JSON.stringify(['GET', key]),
+		(key, value) => JSON.stringify(['SET', key, value]));
 
-	if(typeof(WebSocket) == 'function')
-		f = WebSocket;
-	if(typeof(MozWebSocket) == 'function')
-		f = MozWebSocket;
-
-	var jsonSocket = new f("ws://"+host+":"+port+"/.json");
-	var self = this;
-
-	send = function(j) {
-		var json = JSON.stringify(j);
-		jsonSocket.send(json);
-		log("json-log", "sent", json);
-	};
-
-	jsonSocket.onopen = function() {
-		$("json-log").innerHTML = "";
-		self.send(["SET", "hello", "world"]);
-		self.send(["GET", "hello"]);
-	};
-
-	jsonSocket.onmessage = function(messageEvent) {
-		log("json-log", "received", messageEvent.data);
-	};
-}
-
-function testRAW() {
-
-	if(typeof(WebSocket) == 'function')
-		f = WebSocket;
-	if(typeof(MozWebSocket) == 'function')
-		f = MozWebSocket;
-
-	var rawSocket = new f("ws://"+host+":"+port+"/.raw");
-	var self = this;
-
-	sendRaw = function(raw) {
-		rawSocket.send(raw);
-		log("raw-log", "sent", raw);
-	};
-
-	rawSocket.onopen = function() {
-		$("raw-log").innerHTML = "";
-		self.sendRaw("*3\r\n$3\r\nSET\r\n$5\r\nhello\r\n$5\r\nworld\r\n");
-		self.sendRaw("*2\r\n$3\r\nGET\r\n$5\r\nhello\r\n");
-	};
-
-	rawSocket.onmessage = function(messageEvent) {
-		log("raw-log", "received", messageEvent.data);
-	};
-}
-
-addEventListener("DOMContentLoaded", function(){
-	testJSON();
-	testRAW();
-}, null);
+	const rawClient = new Client('raw',
+		(key) => `*2\r\n$3\r\nGET\r\n$${key.length}\r\n${key}\r\n`,
+		(key, value) =>  `*3\r\n$3\r\nSET\r\n$${key.length}\r\n${key}\r\n$${value.length}\r\n${value}\r\n`);
+});
 
 		</script>
 	</body>

--- a/tests/websocket.html
+++ b/tests/websocket.html
@@ -45,107 +45,72 @@
 
 		<div class="pure-g">
 			<div class="pure-u-1-8"></div>
-			<div class="pure-u-1-3">
-				<h3>JSON</h3>
-				<form class="pure-form">
-					<fieldset>
-						<div class="pure-g">
-							<div class="pure-u-2-3"><label class="ws-state pure-u-23-24" id="json-state">State: Disconnected</label></div>
-							<div class="pure-u-1-3"><button type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-connect">Connect</button></div>
-						</div>
-					</fieldset>
-				</form>
-				<form class="pure-form">
-					<fieldset>
-						<div class="pure-g">
-							<div class="pure-u-2-3">&nbsp;</div>
-							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-ping">Ping</button></div>
-						</div>
-					</fieldset>
-				</form>
-				<form class="pure-form">
-					<fieldset>
-						<div class="pure-g">
-							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="json-set-key" value="hello" /></div>
-							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="value" id="json-set-value" value="world" /></div>
-							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-set">SET</button></div>
-						</div>
-					</fieldset>
-				</form>
-				<form class="pure-form">
-					<fieldset>
-						<div class="pure-g">
-							<div class="pure-u-1-3">&nbsp;</div>
-							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="json-get-key" value="hello" /></div>
-							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-get">GET</button></div>
-						</div>
-					</fieldset>
-				</form>
-
-				<div class="pure-g">
-					<div class="pure-u-2-3">&nbsp;</div>
-					<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-clear">Clear logs</button></div>
-					<div class="log pure-u-1-1" id="json-log">
-					</div>
-				</div>
-			</div>
+			<div class="pure-u-1-3" id="json-container"></div>
 
 			<!-- spacer -->
 			<div class="pure-u-1-12"></div>
 
-			<div class="pure-u-1-3">
-				<h3>Raw</h3>
-				<form class="pure-form">
-					<fieldset>
-						<div class="pure-g">
-							<div class="pure-u-2-3"><label class="ws-state pure-u-23-24" id="raw-state">State: Disconnected</label></div>
-							<div class="pure-u-1-3"><button type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-connect">Connect</button></div>
-						</div>
-					</fieldset>
-				</form>
-				<form class="pure-form">
-					<fieldset>
-						<div class="pure-g">
-							<div class="pure-u-2-3">&nbsp;</div>
-							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-ping">Ping</button></div>
-						</div>
-					</fieldset>
-				</form>
-				<form class="pure-form">
-					<fieldset>
-						<div class="pure-g">
-							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="raw-set-key" value="hello" /></div>
-							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="value" id="raw-set-value" value="world" /></div>
-							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-set">SET</button></div>
-						</div>
-					</fieldset>
-				</form>
-				<form class="pure-form">
-					<fieldset>
-						<div class="pure-g">
-							<div class="pure-u-1-3">&nbsp;</div>
-							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="raw-get-key" value="hello" /></div>
-							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-get">GET</button></div>
-						</div>
-					</fieldset>
-				</form>
-
-				<div class="pure-g">
-					<div class="pure-u-2-3">&nbsp;</div>
-					<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-clear">Clear logs</button></div>
-					<div class="log pure-u-1-1" id="raw-log">
-					</div>
-				</div>
-			</div>
-
+			<div class="pure-u-1-3" id="raw-container"></div>
 			<div class="pure-u-1-8"></div>
 		</div>
+
+<script type="text/javascript">
+</script>
 
 <script type="text/javascript">
 
 $ = function(id) {return document.getElementById(id);};
 const host = "127.0.0.1";
 const port = 7379;
+
+function installBlock(title, type) {
+	const contents = `
+	<h3>$TITLE</h3>
+	<form class="pure-form">
+		<fieldset>
+			<div class="pure-g">
+				<div class="pure-u-2-3"><label class="ws-state pure-u-23-24" id="$type-state">State: Disconnected</label></div>
+				<div class="pure-u-1-3"><button type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="$type-btn-connect">Connect</button></div>
+			</div>
+		</fieldset>
+	</form>
+	<form class="pure-form">
+		<fieldset>
+			<div class="pure-g">
+				<div class="pure-u-2-3">&nbsp;</div>
+				<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="$type-btn-ping">Ping</button></div>
+			</div>
+		</fieldset>
+	</form>
+	<form class="pure-form">
+		<fieldset>
+			<div class="pure-g">
+				<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="$type-set-key" value="hello" /></div>
+				<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="value" id="$type-set-value" value="world" /></div>
+				<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="$type-btn-set">SET</button></div>
+			</div>
+		</fieldset>
+	</form>
+	<form class="pure-form">
+		<fieldset>
+			<div class="pure-g">
+				<div class="pure-u-1-3">&nbsp;</div>
+				<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="$type-get-key" value="hello" /></div>
+				<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="$type-btn-get">GET</button></div>
+			</div>
+		</fieldset>
+	</form>
+
+	<div class="pure-g">
+		<div class="pure-u-2-3">&nbsp;</div>
+		<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="$type-btn-clear">Clear logs</button></div>
+		<div class="log pure-u-1-1" id="$type-log">
+		</div>
+	</div>
+	`;
+	$(`${type}-container`).innerHTML = contents.replace(/\$TITLE/g, title).replace(/\$type/g, type);
+}
+
 
 class Client {
 	constructor(type, pingSerializer, getSerializer, setSerializer) {
@@ -229,6 +194,9 @@ class Client {
 }
 
 addEventListener("DOMContentLoaded", () => {
+	installBlock('JSON', 'json');
+	installBlock('Raw', 'raw');
+
 	const jsonClient = new Client('json',
 		() => JSON.stringify(['PING']),
 		(key) => JSON.stringify(['GET', key]),

--- a/tests/websocket.html
+++ b/tests/websocket.html
@@ -58,6 +58,14 @@
 				<form class="pure-form">
 					<fieldset>
 						<div class="pure-g">
+							<div class="pure-u-2-3">&nbsp;</div>
+							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-ping">Ping</button></div>
+						</div>
+					</fieldset>
+				</form>
+				<form class="pure-form">
+					<fieldset>
+						<div class="pure-g">
 							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="json-set-key" value="hello" /></div>
 							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="value" id="json-set-value" value="world" /></div>
 							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="json-btn-set">SET</button></div>
@@ -98,6 +106,14 @@
 				<form class="pure-form">
 					<fieldset>
 						<div class="pure-g">
+							<div class="pure-u-2-3">&nbsp;</div>
+							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-ping">Ping</button></div>
+						</div>
+					</fieldset>
+				</form>
+				<form class="pure-form">
+					<fieldset>
+						<div class="pure-g">
 							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="key" id="raw-set-key" value="hello" /></div>
 							<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="value" id="raw-set-value" value="world" /></div>
 							<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="raw-btn-set">SET</button></div>
@@ -132,8 +148,9 @@ const host = "127.0.0.1";
 const port = 7379;
 
 class Client {
-	constructor(type, getSerializer, setSerializer) {
+	constructor(type, pingSerializer, getSerializer, setSerializer) {
 		this.type = type;
+		this.pingSerializer = pingSerializer;
 		this.getSerializer = getSerializer;
 		this.setSerializer = setSerializer;
 		this.ws = null;
@@ -158,6 +175,13 @@ class Client {
 			};
 		});
 
+		$(`${this.type}-btn-ping`).addEventListener('click', event => {
+			event.preventDefault();
+			const serialized = this.pingSerializer();
+			this.log("sent", serialized);
+			this.ws.send(serialized);
+		});
+
 		$(`${this.type}-btn-set`).addEventListener('click', event => {
 			event.preventDefault();
 			const serialized = this.setSerializer($(`${this.type}-set-key`).value, $(`${this.type}-set-value`).value);
@@ -180,6 +204,7 @@ class Client {
 
 	setConnectedState(connected) {
 		$(`${this.type}-btn-connect`).disabled = connected;
+		$(`${this.type}-btn-ping`).disabled = !connected;
 		$(`${this.type}-set-key`).disabled = !connected;
 		$(`${this.type}-set-value`).disabled = !connected;
 		$(`${this.type}-btn-set`).disabled = !connected;
@@ -205,10 +230,12 @@ class Client {
 
 addEventListener("DOMContentLoaded", () => {
 	const jsonClient = new Client('json',
+		() => JSON.stringify(['PING']),
 		(key) => JSON.stringify(['GET', key]),
 		(key, value) => JSON.stringify(['SET', key, value]));
 
 	const rawClient = new Client('raw',
+		() => '*1\r\n$4\r\nPING\r\n',
 		(key) => `*2\r\n$3\r\nGET\r\n$${key.length}\r\n${key}\r\n`,
 		(key, value) =>  `*3\r\n$3\r\nSET\r\n$${key.length}\r\n${key}\r\n$${value.length}\r\n${value}\r\n`);
 });

--- a/webdis.json
+++ b/webdis.json
@@ -26,6 +26,6 @@
 		}
 	],
 
-	"verbosity": 6,
+	"verbosity": 4,
 	"logfile": "webdis.log"
 }


### PR DESCRIPTION
This is a long PR attempting to resolve the issues with Websocket tests, as we've discussed in the past.
It is best read commit by commit, rather than as a single diff. I started by cleaning up the websocket test client and ended up rewriting a large part of it to use [libevent buffers](https://libevent.org/doc/bufferevent_8h.html), which made it possible for me to actually understand what was happening and to manage the read and write buffers in the event-driven context.

I then focused on the webdis side of websockets, by adding trace logs everywhere in `src/websocket.c`. With the current implementation I don't think they should cause performance problems. These helped me during debugging but now I am less sure of whether they are really needed or not.

While I was fixing this code I also noticed that the HTML page for testing websockets did not have error handling or much styling so I added some CSS and cleaned up the code, it looks prettier now:

![image](https://user-images.githubusercontent.com/61305023/126051338-b99e9060-2dd5-4b0f-a2d8-548813167fd9.png)

One thing I was not too sure about was whether the websocket test should be included in the GitHub Action that runs on each pull request, but since this is a lot of new test code maybe it should't be part of the validation yet.

@nicolasff this is my largest change made to webdis so far, I hope it's not too long to review. If this is a problem it could probably be split into several smaller pull requests.