### PR TITLE
WebSocket improvements

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -287,14 +287,14 @@ http_client_read(struct http_client *c) {
 		/* broken link, free buffer and client object */
 
 		/* disconnect pub/sub or WS client if there is one. */
-		if(c->self_cmd && c->self_cmd->ac) {
-			struct cmd *cmd = c->self_cmd;
+		if(c->reused_cmd && c->reused_cmd->ac) {
+			struct cmd *cmd = c->reused_cmd;
 
 			/* disconnect from all channels */
-			redisAsyncDisconnect(c->self_cmd->ac);
-			// c->self_cmd might be already cleared by an event handler in redisAsyncDisconnect
+			redisAsyncDisconnect(c->reused_cmd->ac);
+			// c->reused_cmd might be already cleared by an event handler in redisAsyncDisconnect
 			cmd->ac = NULL;
-			c->self_cmd = NULL;
+			c->reused_cmd = NULL;
 
 			/* delete command object */
 			cmd_free(cmd);

--- a/src/client.c
+++ b/src/client.c
@@ -286,15 +286,15 @@ http_client_read(struct http_client *c) {
 	if(ret <= 0) {
 		/* broken link, free buffer and client object */
 
-		/* disconnect pub/sub client if there is one. */
-		if(c->pub_sub && c->pub_sub->ac) {
-			struct cmd *cmd = c->pub_sub;
+		/* disconnect pub/sub or WS client if there is one. */
+		if(c->self_cmd && c->self_cmd->ac) {
+			struct cmd *cmd = c->self_cmd;
 
 			/* disconnect from all channels */
-			redisAsyncDisconnect(c->pub_sub->ac);
-			// c->pub_sub might be already cleared by an event handler in redisAsyncDisconnect
+			redisAsyncDisconnect(c->self_cmd->ac);
+			// c->self_cmd might be already cleared by an event handler in redisAsyncDisconnect
 			cmd->ac = NULL;
-			c->pub_sub = NULL;
+			c->self_cmd = NULL;
 
 			/* delete command object */
 			cmd_free(cmd);

--- a/src/client.h
+++ b/src/client.h
@@ -61,9 +61,12 @@ struct http_client {
 	char *separator; /* list separator for raw lists */
 	char *filename; /* content-disposition */
 
-	struct cmd *pub_sub;
+	struct cmd *self_cmd;
 
-	struct ws_msg *frame; /* websocket frame */
+	struct ws_msg *frame; /* websocket frame (containing *received* data) */
+	struct event ws_wev; /* websocket write event */
+	struct evbuffer *ws_wbuf; /* write buffer for websocket responses */
+	int ws_scheduled_write; /* whether we are already scheduled to send out WS data */
 };
 
 struct http_client *

--- a/src/client.h
+++ b/src/client.h
@@ -63,10 +63,7 @@ struct http_client {
 
 	struct cmd *self_cmd;
 
-	struct ws_msg *frame; /* websocket frame (containing *received* data) */
-	struct event ws_wev; /* websocket write event */
-	struct evbuffer *ws_wbuf; /* write buffer for websocket responses */
-	int ws_scheduled_write; /* whether we are already scheduled to send out WS data */
+	struct ws_client *ws; /* websocket client */
 };
 
 struct http_client *

--- a/src/client.h
+++ b/src/client.h
@@ -61,7 +61,7 @@ struct http_client {
 	char *separator; /* list separator for raw lists */
 	char *filename; /* content-disposition */
 
-	struct cmd *self_cmd;
+	struct cmd *reused_cmd;
 
 	struct ws_client *ws; /* websocket client */
 };

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -375,13 +375,31 @@ cmd_select_format(struct http_client *client, struct cmd *cmd,
 int
 cmd_is_subscribe(struct cmd *cmd) {
 
-	if(cmd->pub_sub_client) { /* persistent command */
+	if(cmd->pub_sub_client || /* persistent command */
+		cmd_is_subscribe_args(cmd)) { /* checked with args */
 		return 1;
 	}
-	if(cmd->count >= 1 && cmd->argv[0] &&
-		(strncasecmp(cmd->argv[0], "SUBSCRIBE", cmd->argv_len[0]) == 0 ||
-		strncasecmp(cmd->argv[0], "PSUBSCRIBE", cmd->argv_len[0]) == 0)) {
-		return 1;
-	}
+	return 0;
+}
+
+int
+cmd_is_subscribe_args(struct cmd *cmd) {
+
+	if(cmd->count >= 2 &&
+		((cmd->argv_len[0] == 9 && strncasecmp(cmd->argv[0], "subscribe", 9) == 0) ||
+		(cmd->argv_len[0] == 10 && strncasecmp(cmd->argv[0], "psubscribe", 10) == 0))) {
+			return 1;
+		}
+	return 0;
+}
+
+int
+cmd_is_unsubscribe_args(struct cmd *cmd) {
+
+	if(cmd->count >= 2 &&
+		((cmd->argv_len[0] == 11 && strncasecmp(cmd->argv[0], "unsubscribe", 11) == 0) ||
+		(cmd->argv_len[0] == 12 && strncasecmp(cmd->argv[0], "punsubscribe", 12) == 0))) {
+			return 1;
+		}
 	return 0;
 }

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -229,7 +229,7 @@ cmd_run(struct worker *w, struct http_client *client,
 		cmd->ac = (redisAsyncContext*)pool_connect(w->pool, cmd->database, 0);
 
 		/* register with the client, used upon disconnection */
-		client->self_cmd = cmd;
+		client->reused_cmd = cmd;
 		cmd->pub_sub_client = client;
 	} else if(cmd->database != w->s->cfg->database) {
 		/* create a new connection to Redis for custom DBs */
@@ -281,7 +281,7 @@ cmd_run(struct worker *w, struct http_client *client,
 	}
 	/* failed to find a suitable connection to Redis. */
 	cmd_free(cmd);
-	client->self_cmd = NULL;
+	client->reused_cmd = NULL;
 	return CMD_REDIS_UNAVAIL;
 }
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -35,11 +35,22 @@ cmd_new(struct http_client *client, int count) {
 	return c;
 }
 
+void
+cmd_free_argv(struct cmd *c) {
+
+	int i;
+	fprintf(stderr, "%s: %p\n", __func__, c);
+	for(i = 0; i < c->count; ++i) {
+		free((char*)c->argv[i]);
+	}
+
+	free(c->argv);
+	free(c->argv_len);
+}
 
 void
 cmd_free(struct cmd *c) {
 
-	int i;
 	if(!c) return;
 
 	free(c->jsonp);
@@ -53,12 +64,7 @@ cmd_free(struct cmd *c) {
 		pool_free_context(c->ac);
 	}
 
-	for(i = 0; i < c->count; ++i) {
-		free((char*)c->argv[i]);
-	}
-
-	free(c->argv);
-	free(c->argv_len);
+	cmd_free_argv(c);
 
 	free(c);
 }

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -22,11 +22,12 @@
 #include <ctype.h>
 
 struct cmd *
-cmd_new(int count) {
+cmd_new(struct http_client *client, int count) {
 
 	struct cmd *c = calloc(1, sizeof(struct cmd));
 
 	c->count = count;
+	c->http_client = client;
 
 	c->argv = calloc(count, sizeof(char*));
 	c->argv_len = calloc(count, sizeof(size_t));
@@ -164,7 +165,7 @@ cmd_run(struct worker *w, struct http_client *client,
 		return CMD_PARAM_ERROR;
 	}
 
-	cmd = cmd_new(param_count);
+	cmd = cmd_new(client, param_count);
 	cmd->fd = client->fd;
 	cmd->database = w->s->cfg->database;
 
@@ -224,7 +225,7 @@ cmd_run(struct worker *w, struct http_client *client,
 		cmd->ac = (redisAsyncContext*)pool_connect(w->pool, cmd->database, 0);
 
 		/* register with the client, used upon disconnection */
-		client->pub_sub = cmd;
+		client->self_cmd = cmd;
 		cmd->pub_sub_client = client;
 	} else if(cmd->database != w->s->cfg->database) {
 		/* create a new connection to Redis for custom DBs */
@@ -276,7 +277,7 @@ cmd_run(struct worker *w, struct http_client *client,
 	}
 	/* failed to find a suitable connection to Redis. */
 	cmd_free(cmd);
-	client->pub_sub = NULL;
+	client->self_cmd = NULL;
 	return CMD_REDIS_UNAVAIL;
 }
 
@@ -370,6 +371,9 @@ cmd_select_format(struct http_client *client, struct cmd *cmd,
 int
 cmd_is_subscribe(struct cmd *cmd) {
 
+	if(cmd->pub_sub_client) { /* persistent command */
+		return 1;
+	}
 	if(cmd->count >= 1 && cmd->argv[0] &&
 		(strncasecmp(cmd->argv[0], "SUBSCRIBE", cmd->argv_len[0]) == 0 ||
 		strncasecmp(cmd->argv[0], "PSUBSCRIBE", cmd->argv_len[0]) == 0)) {

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -39,7 +39,6 @@ void
 cmd_free_argv(struct cmd *c) {
 
 	int i;
-	fprintf(stderr, "%s: %p\n", __func__, c);
 	for(i = 0; i < c->count; ++i) {
 		free((char*)c->argv[i]);
 	}

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -6,7 +6,6 @@
 #include "worker.h"
 #include "http.h"
 #include "server.h"
-#include "slog.h"
 
 #include "formats/json.h"
 #include "formats/raw.h"

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -58,6 +58,9 @@ struct cmd *
 cmd_new(struct http_client *c, int count);
 
 void
+cmd_free_argv(struct cmd *c);
+
+void
 cmd_free(struct cmd *c);
 
 cmd_response_t

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -73,6 +73,12 @@ cmd_select_format(struct http_client *client, struct cmd *cmd,
 		const char *uri, size_t uri_len, formatting_fun *f_format);
 
 int
+cmd_is_subscribe_args(struct cmd *cmd);
+
+int
+cmd_is_unsubscribe_args(struct cmd *cmd);
+
+int
 cmd_is_subscribe(struct cmd *cmd);
 
 void

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -43,6 +43,7 @@ struct cmd {
 	int http_version;
 	int database;
 
+	struct http_client *http_client;
 	struct http_client *pub_sub_client;
 	redisAsyncContext *ac;
 	struct worker *w;
@@ -54,7 +55,7 @@ struct subscription {
 };
 
 struct cmd *
-cmd_new(int count);
+cmd_new(struct http_client *c, int count);
 
 void
 cmd_free(struct cmd *c);

--- a/src/formats/common.c
+++ b/src/formats/common.c
@@ -52,7 +52,7 @@ format_send_error(struct cmd *cmd, short code, const char *msg) {
 
 	if (!cmd->is_websocket) { /* don't free or detach persistent cmd */
 		if (cmd->pub_sub_client) { /* for pub/sub, remove command from client */
-			cmd->pub_sub_client->self_cmd = NULL;
+			cmd->pub_sub_client->reused_cmd = NULL;
 		} else {
 			cmd_free(cmd);
 		}

--- a/src/formats/common.c
+++ b/src/formats/common.c
@@ -48,7 +48,7 @@ format_send_error(struct cmd *cmd, short code, const char *msg) {
 
 	/* for pub/sub, remove command from client */
 	if(cmd->pub_sub_client) {
-		cmd->pub_sub_client->pub_sub = NULL;
+		cmd->pub_sub_client->self_cmd = NULL;
 	} else {
 		cmd_free(cmd);
 	}
@@ -62,7 +62,7 @@ format_send_reply(struct cmd *cmd, const char *p, size_t sz, const char *content
 	struct http_response *resp;
 
 	if(cmd->is_websocket) {
-		ws_reply(cmd, p, sz);
+		ws_frame_and_send_response(cmd, p, sz);
 
 		/* If it's a subscribe command, there'll be more responses */
 		if(!cmd_is_subscribe(cmd))

--- a/src/formats/common.c
+++ b/src/formats/common.c
@@ -7,6 +7,8 @@
 #include "md5/md5.h"
 #include <string.h>
 #include <unistd.h>
+#include <pthread.h>
+#include <ctype.h>
 
 /* TODO: replace this with a faster hash function? */
 char *etag_new(const char *p, size_t sz) {
@@ -62,7 +64,8 @@ format_send_reply(struct cmd *cmd, const char *p, size_t sz, const char *content
 	struct http_response *resp;
 
 	if(cmd->is_websocket) {
-		ws_frame_and_send_response(cmd, p, sz);
+
+		ws_frame_and_send_response(cmd->http_client->ws, WS_BINARY_FRAME, p, sz);
 
 		/* If it's a subscribe command, there'll be more responses */
 		if(!cmd_is_subscribe(cmd))

--- a/src/formats/common.c
+++ b/src/formats/common.c
@@ -46,12 +46,14 @@ format_send_error(struct cmd *cmd, short code, const char *msg) {
 		resp->http_version = cmd->http_version;
 		http_response_set_keep_alive(resp, cmd->keep_alive);
 		http_response_write(resp, cmd->fd);
+	} else if(cmd->is_websocket && !cmd->http_client->ws->close_after_events) {
+		ws_frame_and_send_response(cmd->http_client->ws, WS_BINARY_FRAME, msg, strlen(msg));
 	}
 
 	/* for pub/sub, remove command from client */
 	if(cmd->pub_sub_client) {
 		cmd->pub_sub_client->self_cmd = NULL;
-	} else {
+	} else if (!cmd->is_websocket) { /* don't free persistent cmd */
 		cmd_free(cmd);
 	}
 }

--- a/src/formats/common.c
+++ b/src/formats/common.c
@@ -50,11 +50,12 @@ format_send_error(struct cmd *cmd, short code, const char *msg) {
 		ws_frame_and_send_response(cmd->http_client->ws, WS_BINARY_FRAME, msg, strlen(msg));
 	}
 
-	/* for pub/sub, remove command from client */
-	if(cmd->pub_sub_client) {
-		cmd->pub_sub_client->self_cmd = NULL;
-	} else if (!cmd->is_websocket) { /* don't free persistent cmd */
-		cmd_free(cmd);
+	if (!cmd->is_websocket) { /* don't free or detach persistent cmd */
+		if (cmd->pub_sub_client) { /* for pub/sub, remove command from client */
+			cmd->pub_sub_client->self_cmd = NULL;
+		} else {
+			cmd_free(cmd);
+		}
 	}
 }
 

--- a/src/formats/json.c
+++ b/src/formats/json.c
@@ -522,7 +522,7 @@ json_ws_extract(struct http_client *c, const char *p, size_t sz) {
 	}
 
 	/* create command and add args */
-	cmd = cmd_new(argc);
+	cmd = cmd_new(c, argc);
 	for(i = 0, cur = 0; i < json_array_size(j); ++i) {
 		json_t *jelem = json_array_get(j, i);
 		char *tmp;

--- a/src/formats/raw.c
+++ b/src/formats/raw.c
@@ -62,7 +62,7 @@ raw_ws_extract(struct http_client *c, const char *p, size_t sz) {
 	}
 
 	/* create cmd object */
-	cmd = cmd_new(reply->elements);
+	cmd = cmd_new(c, reply->elements);
 
 	for(i = 0; i < reply->elements; ++i) {
 		redisReply *ri = reply->element[i];

--- a/src/http.c
+++ b/src/http.c
@@ -16,6 +16,10 @@ http_response_init(struct worker *w, int code, const char *msg) {
 
 	/* create object */
 	struct http_response *r = calloc(1, sizeof(struct http_response));
+	if(!r) {
+		if(w && w->s) slog(w->s, WEBDIS_ERROR, "Failed to allocate http_response", 0);
+		return NULL;
+	}
 
 	r->code = code;
 	r->msg = msg;
@@ -40,6 +44,24 @@ http_response_init(struct worker *w, int code, const char *msg) {
 	*/
 	http_response_set_header(r, "Access-Control-Allow-Headers", "X-Requested-With, Content-Type, Authorization");
 
+	return r;
+}
+
+struct http_response *
+http_response_init_with_buffer(struct worker *w, char *data, size_t data_sz, int keep_alive) {
+
+	struct http_response *r = calloc(1, sizeof(struct http_response));
+	if(!r) {
+		if(w && w->s) slog(w->s, WEBDIS_ERROR, "Failed to allocate http_response with buffer", 0);
+		return NULL;
+	}
+	r->w = w;
+
+	/* provide buffer directly */
+	r->out = data;
+	r->out_sz = data_sz;
+	r->sent = 0;
+	r->keep_alive = keep_alive;
 	return r;
 }
 

--- a/src/http.h
+++ b/src/http.h
@@ -45,6 +45,9 @@ struct http_response {
 struct http_response *
 http_response_init(struct worker *w, int code, const char *msg);
 
+struct http_response *
+http_response_init_with_buffer(struct worker *w, char *data, size_t data_sz, int keep_alive);
+
 void
 http_response_set_header(struct http_response *r, const char *k, const char *v);
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -96,6 +96,11 @@ pool_on_disconnect(const redisAsyncContext *ac, int status) {
 
 	struct pool *p = ac->data;
 	int i = 0;
+
+	if(p == NULL) { /* no need to clean anything here. */
+		return;
+	}
+
 	if (status != REDIS_OK) {
 		char format[] = "Error disconnecting: %s";
 		size_t msg_sz = sizeof(format) - 2 + ((ac && ac->errstr) ? strlen(ac->errstr) : 6);
@@ -105,10 +110,6 @@ pool_on_disconnect(const redisAsyncContext *ac, int status) {
 			slog(p->w->s, WEBDIS_ERROR, log_msg, msg_sz-1);
 			free(log_msg);
 		}
-	}
-
-	if(p == NULL) { /* no need to clean anything here. */
-		return;
 	}
 
 	/* remove from the pool */

--- a/src/pool.c
+++ b/src/pool.c
@@ -2,6 +2,7 @@
 #include "worker.h"
 #include "conf.h"
 #include "server.h"
+#include "formats/common.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -30,7 +31,6 @@ pool_free_context(redisAsyncContext *ac) {
 
 	if (ac)	{
 		redisAsyncDisconnect(ac);
-		redisAsyncFree(ac);
 	}
 }
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -2,7 +2,6 @@
 #include "worker.h"
 #include "conf.h"
 #include "server.h"
-#include "formats/common.h"
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/slog.c
+++ b/src/slog.c
@@ -95,8 +95,8 @@ slog_internal(struct server *s, log_level level,
 	time_t now;
 	struct tm now_tm, *lt_ret;
 	char time_buf[64];
-	char msg[124];
-	char line[256]; /* bounds are checked. */
+	char msg[1 + SLOG_MSG_MAX_LEN];
+	char line[2 * SLOG_MSG_MAX_LEN]; /* bounds are checked. */
 	int line_sz, ret;
 
 	if(!s->log.fd) return;

--- a/src/slog.c
+++ b/src/slog.c
@@ -13,6 +13,10 @@
 #include "server.h"
 #include "conf.h"
 
+#if SLOG_MSG_MAX_LEN < 64
+#error "SLOG_MSG_MAX_LEN must be at least 64"
+#endif
+
 /**
  * Initialize log writer.
  */

--- a/src/slog.h
+++ b/src/slog.h
@@ -1,6 +1,8 @@
 #ifndef SLOG_H
 #define SLOG_H
 
+#define SLOG_MSG_MAX_LEN 124
+
 typedef enum {
 	WEBDIS_ERROR = 0,
 	WEBDIS_WARNING,

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -121,7 +121,10 @@ ws_client_free(struct ws_client *ws) {
 	pool_free_context(ws->ac); /* could trigger a cb via format_send_error */
 
 	struct http_client *c = ws->http_client;
-	if(c) c->ws = NULL; /* detach if needed */
+	if(c) {
+		close(c->fd);
+		c->ws = NULL; /* detach if needed */
+	}
 	evbuffer_free(ws->rbuf);
 	evbuffer_free(ws->wbuf);
 	if(ws->cmd) {

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -504,7 +504,13 @@ ws_process_read_data(struct ws_client *ws, unsigned int *out_processed) {
 int
 ws_frame_and_send_response(struct ws_client *ws, enum ws_frame_type frame_type, const char *p, size_t sz) {
 
-	char *frame = malloc(sz + 8); /* create frame by prepending header */
+	/* we can have as much as 14 bytes in the header:
+	 *   1 byte for 4 flag bits + 4 frame type bits
+	 *   1 byte for the payload length indicator
+	 *   8 bytes for the size of the payload (at most)
+	 *   4 bytes for the masking key (if present)
+	 */
+	char *frame = malloc(sz + 14); /* create frame by prepending header */
 	size_t frame_sz = 0;
 	if(frame == NULL)
 		return -1;

--- a/src/websocket.c
+++ b/src/websocket.c
@@ -343,7 +343,7 @@ ws_add_data(struct http_client *c) {
 
 		if(ret != 0) {
 			/* can't process frame. */
-			slog(c->s, WEBDIS_WARNING, "ws_add_data: ws_execute failed", 0);
+			slog(c->s, WEBDIS_DEBUG, "ws_add_data: ws_execute failed", 0);
 			return WS_ERROR;
 		}
 		state = ws_parse_data(c->buffer, c->sz, &c->frame);

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -40,6 +40,7 @@ struct ws_client {
 	/* indicates that we'll close once we've flushed all
 	   buffered data and read what we planned to read */
 	int close_after_events;
+	int ran_subscribe; /* set if we've run a (p)subscribe command */
 };
 
 struct ws_client *

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -3,6 +3,8 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <event.h>
+#include <hiredis/async.h>
 
 struct http_client;
 struct cmd;
@@ -12,19 +14,47 @@ enum ws_state {
 	WS_READING,
 	WS_MSG_COMPLETE};
 
+enum ws_frame_type {
+	WS_TEXT_FRAME = 0,
+	WS_BINARY_FRAME = 1,
+	WS_CONNECTION_CLOSE = 8,
+	WS_PING = 9,
+	WS_PONG = 0xA,
+	WS_UNKNOWN_FRAME = -1};
+
 struct ws_msg {
+	enum ws_frame_type type;
 	char *payload;
 	size_t payload_sz;
 	size_t total_sz;
 };
 
+struct ws_client {
+	struct http_client *http_client; /* parent */
+	int scheduled_read; /* set if we are scheduled to read WS data */
+	int scheduled_write; /* set if we are scheduled to send out WS data */
+	struct evbuffer *rbuf; /* read buffer for incoming data */
+	struct evbuffer *wbuf; /* write buffer for outgoing data */
+	redisAsyncContext *ac; /* dedicated connection to redis */
+	struct cmd *cmd; /* current command */
+	/* indicates that we'll close once we've flushed all
+	   buffered data and read what we planned to read */
+	int close_after_events;
+};
+
+struct ws_client *
+ws_client_new(struct http_client *http_client);
+
 int
-ws_handshake_reply(struct http_client *c);
+ws_handshake_reply(struct ws_client *ws);
+
+void
+ws_monitor_input(struct ws_client *ws);
 
 enum ws_state
-ws_add_data(struct http_client *c);
+ws_process_read_data(struct ws_client *ws, unsigned int *out_processed);
 
 int
-ws_frame_and_send_response(struct cmd *cmd, const char *p, size_t sz);
+ws_frame_and_send_response(struct ws_client *ws, enum ws_frame_type type, const char *p, size_t sz);
 
 #endif

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -45,10 +45,13 @@ struct ws_client {
 struct ws_client *
 ws_client_new(struct http_client *http_client);
 
+void
+ws_client_free(struct ws_client *ws);
+
 int
 ws_handshake_reply(struct ws_client *ws);
 
-void
+int
 ws_monitor_input(struct ws_client *ws);
 
 enum ws_state

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -25,6 +25,6 @@ enum ws_state
 ws_add_data(struct http_client *c);
 
 int
-ws_reply(struct cmd *cmd, const char *p, size_t sz);
+ws_frame_and_send_response(struct cmd *cmd, const char *p, size_t sz);
 
 #endif

--- a/src/worker.c
+++ b/src/worker.c
@@ -108,11 +108,8 @@ worker_can_read(int fd, short event, void *p) {
 			close(c->fd);
 		}
 		http_client_free(c);
-	} else {
-		/* start monitoring input again */
-		if(c->is_websocket) { /* all communication handled by WS code from now on */
-			// ws_monitor_input(c->ws);
-		} else {
+	} else { /* start monitoring input again */
+		if(!c->is_websocket) { /* all communication handled by WS code from now on */
 			worker_monitor_input(c);
 		}
 	}

--- a/tests/limits.py
+++ b/tests/limits.py
@@ -12,6 +12,9 @@ class BlockingSocket:
 		self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		self.s.setblocking(True)
 		self.s.connect((HOST, PORT))
+	
+	def __del__(self):
+		self.s.close()
 
 	def recv(self):
 		out = b""

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,1 @@
+websocket-client>=1.1.0

--- a/tests/websocket.html
+++ b/tests/websocket.html
@@ -101,6 +101,26 @@ function installBlock(title, type) {
 		</fieldset>
 	</form>
 
+	<form class="pure-form">
+		<fieldset>
+			<div class="pure-g">
+				<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="channel name" id="$type-pub-channel" value="channel-0" /></div>
+				<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="message value" id="$type-pub-message" value="message-0" /></div>
+				<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="$type-btn-pub">PUBLISH</button></div>
+			</div>
+		</fieldset>
+	</form>
+
+	<form class="pure-form">
+		<fieldset>
+			<div class="pure-g">
+				<div class="pure-u-1-3">&nbsp;</div>
+				<div class="pure-u-1-3"><input disabled class="pure-u-23-24" type="text" placeholder="channel" id="$type-sub-channel" value="channel-0" /></div>
+				<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="$type-btn-sub">SUBSCRIBE</button></div>
+			</div>
+		</fieldset>
+	</form>
+
 	<div class="pure-g">
 		<div class="pure-u-2-3">&nbsp;</div>
 		<div class="pure-u-1-3"><button disabled type="submit" class="pure-u-23-24 pure-button pure-button-primary" id="$type-btn-clear">Clear logs</button></div>
@@ -113,17 +133,23 @@ function installBlock(title, type) {
 
 
 class Client {
-	constructor(type, pingSerializer, getSerializer, setSerializer) {
+	constructor(type, pingSerializer, getSerializer, setSerializer, pubSerializer, subSerializer) {
 		this.type = type;
 		this.pingSerializer = pingSerializer;
 		this.getSerializer = getSerializer;
 		this.setSerializer = setSerializer;
+		this.pubSerializer = pubSerializer;
+		this.subSerializer = subSerializer;
 		this.ws = null;
+		this.connected = false;
+		this.subscribed = false;
+		this.logCount = 0;
 
 		$(`${this.type}-btn-connect`).addEventListener('click', event => {
 			event.preventDefault();
 			console.log('Connecting...');
-			this.ws = new WebSocket(`ws://${ host }:${ port }/.${ this.type }`);
+			this.ws = new WebSocket(`ws://${host}:${port}/.${this.type}`);
+			window.ws = this.ws;
 			this.ws.onopen = event => {
 				console.log('Connected');
 				this.setConnectedState(true);
@@ -135,48 +161,81 @@ class Client {
 			};
 
 			this.ws.onclose = event => {
-				$(`${this.type}-btn-connect`).disabled = false;
+				console.log('ON CLOSE')
+				$(`${this.type}-btn-connect`).innerText = 'Connect';
 				this.setConnectedState(false);
+				this.subscribed = false;
 			};
 		});
 
 		$(`${this.type}-btn-ping`).addEventListener('click', event => {
 			event.preventDefault();
 			const serialized = this.pingSerializer();
-			this.log("sent", serialized);
-			this.ws.send(serialized);
+			this.send(serialized);
 		});
 
 		$(`${this.type}-btn-set`).addEventListener('click', event => {
 			event.preventDefault();
 			const serialized = this.setSerializer($(`${this.type}-set-key`).value, $(`${this.type}-set-value`).value);
-			this.log("sent", serialized);
-			this.ws.send(serialized);
+			this.send(serialized);
 		});
 
 		$(`${this.type}-btn-get`).addEventListener('click', event => {
 			event.preventDefault();
-			const serialized = this.getSerializer($(`${this.type}-set-key`).value);
-			this.log("sent", serialized);
-			this.ws.send(serialized);
+			const serialized = this.getSerializer($(`${this.type}-get-key`).value);
+			this.send(serialized);
+		});
+
+		$(`${this.type}-btn-pub`).addEventListener('click', event => {
+			event.preventDefault();
+			const serialized = this.pubSerializer($(`${this.type}-pub-channel`).value, $(`${this.type}-pub-message`).value);
+			this.send(serialized);
+		});
+
+		$(`${this.type}-btn-sub`).addEventListener('click', event => {
+			event.preventDefault();
+			const serialized = this.subSerializer($(`${this.type}-sub-channel`).value);
+			try {
+				this.send(serialized);
+				this.subscribed = true;
+				this.setConnectedState(true);
+			} catch (e) {
+			}
 		});
 
 		$(`${this.type}-btn-clear`).addEventListener('click', event => {
 			event.preventDefault();
 			$(`${this.type}-log`).innerText = "";
+			this.logCount = 0;
+			this.updateLogButton();
 		});
 	}
 
+	send(serialized) {
+		this.log("sent", serialized);
+		this.ws.send(serialized);
+	}
+
 	setConnectedState(connected) {
+		this.connected = connected;
 		$(`${this.type}-btn-connect`).disabled = connected;
-		$(`${this.type}-btn-ping`).disabled = !connected;
-		$(`${this.type}-set-key`).disabled = !connected;
-		$(`${this.type}-set-value`).disabled = !connected;
-		$(`${this.type}-btn-set`).disabled = !connected;
-		$(`${this.type}-get-key`).disabled = !connected;
-		$(`${this.type}-btn-get`).disabled = !connected;
-		$(`${this.type}-btn-clear`).disabled = !connected;
+		$(`${this.type}-btn-ping`).disabled = !connected || this.subscribed;
+		$(`${this.type}-set-key`).disabled = !connected || this.subscribed;
+		$(`${this.type}-set-value`).disabled = !connected || this.subscribed;
+		$(`${this.type}-btn-set`).disabled = !connected || this.subscribed;
+		$(`${this.type}-get-key`).disabled = !connected || this.subscribed;
+		$(`${this.type}-btn-get`).disabled = !connected || this.subscribed;
+		$(`${this.type}-pub-channel`).disabled = !connected || this.subscribed;
+		$(`${this.type}-pub-message`).disabled = !connected || this.subscribed;
+		$(`${this.type}-btn-pub`).disabled = !connected || this.subscribed;
+		$(`${this.type}-sub-channel`).disabled = !connected || this.subscribed;
+		$(`${this.type}-btn-sub`).disabled = !connected || this.subscribed;
+
 		$(`${this.type}-state`).innerText = `State: ${connected ? 'Connected' : 'Disconnected'}`;
+	}
+
+	updateLogButton() {
+		$(`${this.type}-btn-clear`).disabled = this.logCount === 0;
 	}
 
 	log(dir, msg) {
@@ -190,6 +249,8 @@ class Client {
 		contents.setAttribute("class", dir);
 		contents.innerHTML = msg;
 		$(id).appendChild(contents);
+		this.logCount++;
+		this.updateLogButton();
 	}
 }
 
@@ -200,12 +261,16 @@ addEventListener("DOMContentLoaded", () => {
 	const jsonClient = new Client('json',
 		() => JSON.stringify(['PING']),
 		(key) => JSON.stringify(['GET', key]),
-		(key, value) => JSON.stringify(['SET', key, value]));
+		(key, value) => JSON.stringify(['SET', key, value]),
+		(channel, message) => JSON.stringify(['PUBLISH', channel, message]),
+		(channel) => JSON.stringify(['SUBSCRIBE', channel]));
 
 	const rawClient = new Client('raw',
 		() => '*1\r\n$4\r\nPING\r\n',
 		(key) => `*2\r\n$3\r\nGET\r\n$${key.length}\r\n${key}\r\n`,
-		(key, value) =>  `*3\r\n$3\r\nSET\r\n$${key.length}\r\n${key}\r\n$${value.length}\r\n${value}\r\n`);
+		(key, value) =>  `*3\r\n$3\r\nSET\r\n$${key.length}\r\n${key}\r\n$${value.length}\r\n${value}\r\n`,
+		(channel, message) =>  `*3\r\n$7\r\nPUBLISH\r\n$${channel.length}\r\n${channel}\r\n$${message.length}\r\n${message}\r\n`,
+		(channel) =>  `*2\r\n$9\r\nSUBSCRIBE\r\n$${channel.length}\r\n${channel}\r\n`);
 });
 
 		</script>

--- a/tests/websocket.html
+++ b/tests/websocket.html
@@ -161,7 +161,6 @@ class Client {
 			};
 
 			this.ws.onclose = event => {
-				console.log('ON CLOSE')
 				$(`${this.type}-btn-connect`).innerText = 'Connect';
 				this.setConnectedState(false);
 				this.subscribed = false;
@@ -200,6 +199,7 @@ class Client {
 				this.subscribed = true;
 				this.setConnectedState(true);
 			} catch (e) {
+				console.log('Error sending: ', serialized, e);
 			}
 		});
 

--- a/tests/websocket.html
+++ b/tests/websocket.html
@@ -133,13 +133,9 @@ function installBlock(title, type) {
 
 
 class Client {
-	constructor(type, pingSerializer, getSerializer, setSerializer, pubSerializer, subSerializer) {
+	constructor(type, serializer) {
 		this.type = type;
-		this.pingSerializer = pingSerializer;
-		this.getSerializer = getSerializer;
-		this.setSerializer = setSerializer;
-		this.pubSerializer = pubSerializer;
-		this.subSerializer = subSerializer;
+		this.serializer = serializer;
 		this.ws = null;
 		this.connected = false;
 		this.subscribed = false;
@@ -169,31 +165,31 @@ class Client {
 
 		$(`${this.type}-btn-ping`).addEventListener('click', event => {
 			event.preventDefault();
-			const serialized = this.pingSerializer();
+			const serialized = this.serializer(['PING']);
 			this.send(serialized);
 		});
 
 		$(`${this.type}-btn-set`).addEventListener('click', event => {
 			event.preventDefault();
-			const serialized = this.setSerializer($(`${this.type}-set-key`).value, $(`${this.type}-set-value`).value);
+			const serialized = this.serializer(['SET', $(`${this.type}-set-key`).value, $(`${this.type}-set-value`).value]);
 			this.send(serialized);
 		});
 
 		$(`${this.type}-btn-get`).addEventListener('click', event => {
 			event.preventDefault();
-			const serialized = this.getSerializer($(`${this.type}-get-key`).value);
+			const serialized = this.serializer(['GET', $(`${this.type}-get-key`).value]);
 			this.send(serialized);
 		});
 
 		$(`${this.type}-btn-pub`).addEventListener('click', event => {
 			event.preventDefault();
-			const serialized = this.pubSerializer($(`${this.type}-pub-channel`).value, $(`${this.type}-pub-message`).value);
+			const serialized = this.serializer(['PUBLISH', $(`${this.type}-pub-channel`).value, $(`${this.type}-pub-message`).value]);
 			this.send(serialized);
 		});
 
 		$(`${this.type}-btn-sub`).addEventListener('click', event => {
 			event.preventDefault();
-			const serialized = this.subSerializer($(`${this.type}-sub-channel`).value);
+			const serialized = this.serializer(['SUBSCRIBE', $(`${this.type}-sub-channel`).value]);
 			try {
 				this.send(serialized);
 				this.subscribed = true;
@@ -254,23 +250,21 @@ class Client {
 	}
 }
 
+function serializeRaw(args) {
+	let raw = `*${args.length}\r\n`;
+	for (let i = 0; i < args.length; i++) {
+		raw += `$${args[i].length}\r\n`;
+		raw += `${args[i]}\r\n`;
+	}
+	return raw;
+}
+
 addEventListener("DOMContentLoaded", () => {
 	installBlock('JSON', 'json');
 	installBlock('Raw', 'raw');
 
-	const jsonClient = new Client('json',
-		() => JSON.stringify(['PING']),
-		(key) => JSON.stringify(['GET', key]),
-		(key, value) => JSON.stringify(['SET', key, value]),
-		(channel, message) => JSON.stringify(['PUBLISH', channel, message]),
-		(channel) => JSON.stringify(['SUBSCRIBE', channel]));
-
-	const rawClient = new Client('raw',
-		() => '*1\r\n$4\r\nPING\r\n',
-		(key) => `*2\r\n$3\r\nGET\r\n$${key.length}\r\n${key}\r\n`,
-		(key, value) =>  `*3\r\n$3\r\nSET\r\n$${key.length}\r\n${key}\r\n$${value.length}\r\n${value}\r\n`,
-		(channel, message) =>  `*3\r\n$7\r\nPUBLISH\r\n$${channel.length}\r\n${channel}\r\n$${message.length}\r\n${message}\r\n`,
-		(channel) =>  `*2\r\n$9\r\nSUBSCRIBE\r\n$${channel.length}\r\n${channel}\r\n`);
+	const jsonClient = new Client('json', JSON.stringify);
+	const rawClient = new Client('raw', serializeRaw);
 });
 
 		</script>

--- a/tests/ws-tests.py
+++ b/tests/ws-tests.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+import abc
+import json
+import os
+import unittest
+import uuid
+from websocket import create_connection
+
+host = os.getenv('WEBDIS_HOST', '127.0.0.1')
+port = int(os.getenv('WEBDIS_PORT', 7379))
+
+class TestWebdis(unittest.TestCase):
+	def setUp(self) -> None:
+		self.ws = create_connection(f'ws://{host}:{port}/.{self.format()}')
+
+	def tearDown(self) -> None:
+		self.ws.close()
+
+	def exec(self, cmd, *args):
+		self.ws.send(self.serialize(cmd, *args))
+		return self.deserialize(self.ws.recv())
+
+	def clean_key(self):
+		"""Returns a key that was just deleted"""
+		key = str(uuid.uuid4())
+		self.exec('DEL', key)
+		return key
+
+	@abc.abstractmethod
+	def format(self):
+		"""Returns the format to use (added after a dot to the WS URI)"""
+		return
+	
+	@abc.abstractmethod
+	def serialize(self, cmd):
+		"""Serializes a command according to the format being tested"""
+		return
+
+	@abc.abstractmethod
+	def deserialize(self, response):
+		"""Deserializes a response according to the format being tested"""
+		return
+
+
+class TestJson(TestWebdis):
+	def format(self):
+		return 'json'
+
+	def serialize(self, cmd, *args):
+		return json.dumps([cmd] + list(args))
+
+	def deserialize(self, response):
+		return json.loads(response)
+
+	def test_ping(self):
+		self.assertEqual(self.exec('PING'), {'PING': [True, 'PONG']})
+
+	def test_multiple_messages(self):
+		key = self.clean_key()
+		n = 100
+		for i in range(n):
+			lpush_response = self.exec('LPUSH', key, f'value-{i}')
+			self.assertEqual(lpush_response, {'LPUSH': i + 1})
+		self.assertEqual(self.exec('LLEN', key), {'LLEN': n})
+
+
+class TestRaw(TestWebdis):
+	def format(self):
+		return 'raw'
+
+	def serialize(self, cmd, *args):
+		buffer = f"*{1 + len(args)}\r\n${len(cmd)}\r\n{cmd}\r\n"
+		for arg in args:
+			buffer += f"${len(arg)}\r\n{arg}\r\n"
+		return buffer
+
+	def deserialize(self, response):
+		return response # we'll just assert using the raw protocol
+
+	def test_ping(self):
+		self.assertEqual(self.exec('PING'), "+PONG\r\n")
+
+	def test_get_set(self):
+		key = self.clean_key()
+		value = str(uuid.uuid4())
+		not_found_response = self.exec('GET', key)
+		self.assertEqual(not_found_response, "$-1\r\n")  # Redis protocol response for "not found"
+		set_response = self.exec('SET', key, value)
+		self.assertEqual(set_response, "+OK\r\n")
+		get_response = self.exec('GET', key)
+		self.assertEqual(get_response, f"${len(value)}\r\n{value}\r\n")
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/ws-tests.py
+++ b/tests/ws-tests.py
@@ -10,160 +10,163 @@ from websocket import create_connection
 host = os.getenv('WEBDIS_HOST', '127.0.0.1')
 port = int(os.getenv('WEBDIS_PORT', 7379))
 
+
 def connect(format):
-	return create_connection(f'ws://{host}:{port}/.{format}')
+    return create_connection(f'ws://{host}:{port}/.{format}')
+
 
 class TestWebdis(unittest.TestCase):
-	def setUp(self) -> None:
-		self.ws = connect(self.format())
+    def setUp(self) -> None:
+        self.ws = connect(self.format())
 
-	def tearDown(self) -> None:
-		self.ws.close()
+    def tearDown(self) -> None:
+        self.ws.close()
 
-	def exec(self, cmd, *args):
-		self.ws.send(self.serialize(cmd, *args))
-		return self.deserialize(self.ws.recv())
+    def exec(self, cmd, *args):
+        self.ws.send(self.serialize(cmd, *args))
+        return self.deserialize(self.ws.recv())
 
-	def clean_key(self):
-		"""Returns a key that was just deleted"""
-		key = str(uuid.uuid4())
-		self.exec('DEL', key)
-		return key
+    def clean_key(self):
+        """Returns a key that was just deleted"""
+        key = str(uuid.uuid4())
+        self.exec('DEL', key)
+        return key
 
-	@abc.abstractmethod
-	def format(self):
-		"""Returns the format to use (added after a dot to the WS URI)"""
-		return
-	
-	@abc.abstractmethod
-	def serialize(self, cmd):
-		"""Serializes a command according to the format being tested"""
-		return
+    @abc.abstractmethod
+    def format(self):
+        """Returns the format to use (added after a dot to the WS URI)"""
+        return
 
-	@abc.abstractmethod
-	def deserialize(self, response):
-		"""Deserializes a response according to the format being tested"""
-		return
+    @abc.abstractmethod
+    def serialize(self, cmd):
+        """Serializes a command according to the format being tested"""
+        return
+
+    @abc.abstractmethod
+    def deserialize(self, response):
+        """Deserializes a response according to the format being tested"""
+        return
 
 
 class TestJson(TestWebdis):
-	def format(self):
-		return 'json'
+    def format(self):
+        return 'json'
 
-	def serialize(self, cmd, *args):
-		return json.dumps([cmd] + list(args))
+    def serialize(self, cmd, *args):
+        return json.dumps([cmd] + list(args))
 
-	def deserialize(self, response):
-		return json.loads(response)
+    def deserialize(self, response):
+        return json.loads(response)
 
-	def test_ping(self):
-		self.assertEqual(self.exec('PING'), {'PING': [True, 'PONG']})
+    def test_ping(self):
+        self.assertEqual(self.exec('PING'), {'PING': [True, 'PONG']})
 
-	def test_multiple_messages(self):
-		key = self.clean_key()
-		n = 100
-		for i in range(n):
-			lpush_response = self.exec('LPUSH', key, f'value-{i}')
-			self.assertEqual(lpush_response, {'LPUSH': i + 1})
-		self.assertEqual(self.exec('LLEN', key), {'LLEN': n})
+    def test_multiple_messages(self):
+        key = self.clean_key()
+        n = 100
+        for i in range(n):
+            lpush_response = self.exec('LPUSH', key, f'value-{i}')
+            self.assertEqual(lpush_response, {'LPUSH': i + 1})
+        self.assertEqual(self.exec('LLEN', key), {'LLEN': n})
 
 
 class TestRaw(TestWebdis):
-	def format(self):
-		return 'raw'
+    def format(self):
+        return 'raw'
 
-	def serialize(self, cmd, *args):
-		buffer = f"*{1 + len(args)}\r\n${len(cmd)}\r\n{cmd}\r\n"
-		for arg in args:
-			buffer += f"${len(arg)}\r\n{arg}\r\n"
-		return buffer
+    def serialize(self, cmd, *args):
+        buffer = f"*{1 + len(args)}\r\n${len(cmd)}\r\n{cmd}\r\n"
+        for arg in args:
+            buffer += f"${len(arg)}\r\n{arg}\r\n"
+        return buffer
 
-	def deserialize(self, response):
-		return response # we'll just assert using the raw protocol
+    def deserialize(self, response):
+        return response  # we'll just assert using the raw protocol
 
-	def test_ping(self):
-		self.assertEqual(self.exec('PING'), "+PONG\r\n")
+    def test_ping(self):
+        self.assertEqual(self.exec('PING'), "+PONG\r\n")
 
-	def test_get_set(self):
-		key = self.clean_key()
-		value = str(uuid.uuid4())
-		not_found_response = self.exec('GET', key)
-		self.assertEqual(not_found_response, "$-1\r\n")  # Redis protocol response for "not found"
-		set_response = self.exec('SET', key, value)
-		self.assertEqual(set_response, "+OK\r\n")
-		get_response = self.exec('GET', key)
-		self.assertEqual(get_response, f"${len(value)}\r\n{value}\r\n")
+    def test_get_set(self):
+        key = self.clean_key()
+        value = str(uuid.uuid4())
+        not_found_response = self.exec('GET', key)
+        self.assertEqual(not_found_response, "$-1\r\n")  # Redis protocol response for "not found"
+        set_response = self.exec('SET', key, value)
+        self.assertEqual(set_response, "+OK\r\n")
+        get_response = self.exec('GET', key)
+        self.assertEqual(get_response, f"${len(value)}\r\n{value}\r\n")
 
 
 @unittest.skipIf(os.getenv('PUBSUB') != '1', "pub-sub test fail due to invalid ordering")
 class TestPubSub(unittest.TestCase):
-	def setUp(self):
-		self.publisher = connect('json')
-		self.subscriber = connect('json')
+    def setUp(self):
+        self.publisher = connect('json')
+        self.subscriber = connect('json')
 
-	def tearDown(self):
-		self.publisher.close()
-		self.subscriber.close()
+    def tearDown(self):
+        self.publisher.close()
+        self.subscriber.close()
 
-	def serialize(self, cmd, *args):
-		return json.dumps([cmd] + list(args))
+    def serialize(self, cmd, *args):
+        return json.dumps([cmd] + list(args))
 
-	def deserialize(self, response):
-		return json.loads(response)
+    def deserialize(self, response):
+        return json.loads(response)
 
-	def test_publish_subscribe(self):
-		channel_count = 2
-		message_count_per_channel = 8
-		channels = list(str(uuid.uuid4()) for i in range(channel_count))
+    def test_publish_subscribe(self):
+        channel_count = 2
+        message_count_per_channel = 8
+        channels = list(str(uuid.uuid4()) for i in range(channel_count))
 
-		# subscribe to all channels
-		sub_count = 0
-		for channel in channels:
-			self.subscriber.send(self.serialize('SUBSCRIBE', channel))
-			sub_response = self.deserialize(self.subscriber.recv())
-			sub_count += 1
-			self.assertEqual(sub_response, {'SUBSCRIBE': ['subscribe', channel, sub_count]})
+        # subscribe to all channels
+        sub_count = 0
+        for channel in channels:
+            self.subscriber.send(self.serialize('SUBSCRIBE', channel))
+            sub_response = self.deserialize(self.subscriber.recv())
+            sub_count += 1
+            self.assertEqual(sub_response, {'SUBSCRIBE': ['subscribe', channel, sub_count]})
 
-		# send messages to all channels
-		prefix = 'message-'
-		for i in range(message_count_per_channel):
-			for channel in channels:
-				message = f'{prefix}{i}'
-				self.publisher.send(self.serialize('PUBLISH', channel, message))
-				self.deserialize(self.publisher.recv())
+        # send messages to all channels
+        prefix = 'message-'
+        for i in range(message_count_per_channel):
+            for channel in channels:
+                message = f'{prefix}{i}'
+                self.publisher.send(self.serialize('PUBLISH', channel, message))
+                self.deserialize(self.publisher.recv())
 
-		received_per_channel = dict((channel, []) for channel in channels)
-		for j in range(channel_count * message_count_per_channel):
-			received = self.deserialize(self.subscriber.recv())
-			# expected: {'SUBSCRIBE': ['message', $channel, $message]}
-			self.assertTrue(received, 'SUBSCRIBE' in received)
-			sub_contents = received['SUBSCRIBE']
-			self.assertEqual(len(sub_contents), 3)
+        received_per_channel = dict((channel, []) for channel in channels)
+        for j in range(channel_count * message_count_per_channel):
+            received = self.deserialize(self.subscriber.recv())
+            # expected: {'SUBSCRIBE': ['message', $channel, $message]}
+            self.assertTrue(received, 'SUBSCRIBE' in received)
+            sub_contents = received['SUBSCRIBE']
+            self.assertEqual(len(sub_contents), 3)
 
-			self.assertEqual(sub_contents[0], 'message')  # first element is the message type, here a push
-			channel = sub_contents[1]
-			self.assertTrue(channel in channels)  # second is the channel
-			received_per_channel[channel].append(sub_contents[2])  # third, add to list of messages received for this channel
+            self.assertEqual(sub_contents[0], 'message')  # first element is the message type, here a push
+            channel = sub_contents[1]
+            self.assertTrue(channel in channels)  # second is the channel
+            received_per_channel[channel].append(
+                sub_contents[2])  # third, add to list of messages received for this channel
 
-		# unsubscribe from all channels
-		subs_remaining = channel_count
-		for channel in channels:
-			self.subscriber.send(self.serialize('UNSUBSCRIBE', channel))
-			subs_remaining -= 1
-			unsub_response = self.deserialize(self.subscriber.recv())
-			self.assertEqual(unsub_response, {'UNSUBSCRIBE': ['unsubscribe', channel, subs_remaining]})
+        # unsubscribe from all channels
+        subs_remaining = channel_count
+        for channel in channels:
+            self.subscriber.send(self.serialize('UNSUBSCRIBE', channel))
+            subs_remaining -= 1
+            unsub_response = self.deserialize(self.subscriber.recv())
+            self.assertEqual(unsub_response, {'UNSUBSCRIBE': ['unsubscribe', channel, subs_remaining]})
 
-		# check that we received all messages
-		for channel in channels:
-			self.assertEqual(len(received_per_channel[channel]), message_count_per_channel)
+        # check that we received all messages
+        for channel in channels:
+            self.assertEqual(len(received_per_channel[channel]), message_count_per_channel)
 
-		# check that we received them *in order*
-		for i in range(message_count_per_channel):
-			for channel in channels:
-				expected = f'{prefix}{i}'
-				self.assertEqual(received_per_channel[channel][i], expected,
-					f'In {channel}: expected at offset {i} was "{expected}", actual was: "{received_per_channel[channel][i]}"')
+        # check that we received them *in order*
+        for i in range(message_count_per_channel):
+            for channel in channels:
+                expected = f'{prefix}{i}'
+                self.assertEqual(received_per_channel[channel][i], expected,
+                                 f'In {channel}: expected at offset {i} was "{expected}", actual was: "{received_per_channel[channel][i]}"')
 
 
 if __name__ == '__main__':
-	unittest.main()
+    unittest.main()

--- a/tests/ws-tests.py
+++ b/tests/ws-tests.py
@@ -178,17 +178,16 @@ class TestFrameSizes(TestWebdis):
         return json.loads(response)
 
     def test_length_126(self):
-        key = str(uuid.uuid4())
-        value = 'A' * 1024  # this will require 2 bytes to encode the length
-        self.assertEqual(self.exec('SET', key, value), {'SET': [True, 'OK']})
-        self.exec('DEL', key)
+        self.validate_set_get('A' * 1024)  # this will require 2 bytes to encode the length
 
     def test_length_127(self):
-        key = str(uuid.uuid4())
-        value = 'A' * (2 ** 18)  # this will require more than 2 bytes to encode the length (actually using 8)
-        self.assertEqual(self.exec('SET', key, value), {'SET': [True, 'OK']})
-        self.exec('DEL', key)
+        self.validate_set_get('A' * (2 ** 18))   # this will require more than 2 bytes to encode the length (actually using 8)
 
+    def validate_set_get(self, value):
+        key = str(uuid.uuid4())
+        self.assertEqual(self.exec('SET', key, value), {'SET': [True, 'OK']})
+        self.assertEqual(self.exec('GET', key), {'GET': value})
+        self.exec('DEL', key)
 
 
 if __name__ == '__main__':

--- a/tests/ws-tests.py
+++ b/tests/ws-tests.py
@@ -117,9 +117,9 @@ class TestPubSub(unittest.TestCase):
 		sub_count = 0
 		for channel in channels:
 			self.subscriber.send(self.serialize('SUBSCRIBE', channel))
-			unsub_response = self.deserialize(self.subscriber.recv())
+			sub_response = self.deserialize(self.subscriber.recv())
 			sub_count += 1
-			self.assertEqual(unsub_response, {'SUBSCRIBE': ['subscribe', channel, sub_count]})
+			self.assertEqual(sub_response, {'SUBSCRIBE': ['subscribe', channel, sub_count]})
 
 		# send messages to all channels
 		prefix = 'message-'
@@ -127,11 +127,11 @@ class TestPubSub(unittest.TestCase):
 			for channel in channels:
 				message = f'{prefix}{i}'
 				self.publisher.send(self.serialize('PUBLISH', channel, message))
+				self.deserialize(self.publisher.recv())
 
 		received_per_channel = dict((channel, []) for channel in channels)
 		for j in range(channel_count * message_count_per_channel):
 			received = self.deserialize(self.subscriber.recv())
-			print('received:', received)
 			# expected: {'SUBSCRIBE': ['message', $channel, $message]}
 			self.assertTrue(received, 'SUBSCRIBE' in received)
 			sub_contents = received['SUBSCRIBE']
@@ -148,7 +148,7 @@ class TestPubSub(unittest.TestCase):
 			self.subscriber.send(self.serialize('UNSUBSCRIBE', channel))
 			subs_remaining -= 1
 			unsub_response = self.deserialize(self.subscriber.recv())
-			self.assertEqual(unsub_response, {'SUBSCRIBE': ['unsubscribe', channel, subs_remaining]})
+			self.assertEqual(unsub_response, {'UNSUBSCRIBE': ['unsubscribe', channel, subs_remaining]})
 
 		# check that we received all messages
 		for channel in channels:

--- a/tests/ws-tests.py
+++ b/tests/ws-tests.py
@@ -10,9 +10,12 @@ from websocket import create_connection
 host = os.getenv('WEBDIS_HOST', '127.0.0.1')
 port = int(os.getenv('WEBDIS_PORT', 7379))
 
+def connect(format):
+	return create_connection(f'ws://{host}:{port}/.{format}')
+
 class TestWebdis(unittest.TestCase):
 	def setUp(self) -> None:
-		self.ws = create_connection(f'ws://{host}:{port}/.{self.format()}')
+		self.ws = connect(self.format())
 
 	def tearDown(self) -> None:
 		self.ws.close()
@@ -95,8 +98,8 @@ class TestRaw(TestWebdis):
 @unittest.skipIf(os.getenv('PUBSUB') != '1', "pub-sub test fail due to invalid ordering")
 class TestPubSub(unittest.TestCase):
 	def setUp(self):
-		self.publisher = create_connection(f'ws://{host}:{port}/.json')
-		self.subscriber = create_connection(f'ws://{host}:{port}/.json')
+		self.publisher = connect('json')
+		self.subscriber = connect('json')
 
 	def tearDown(self):
 		self.publisher.close()

--- a/tests/ws-tests.py
+++ b/tests/ws-tests.py
@@ -167,5 +167,29 @@ class TestPubSub(unittest.TestCase):
                                  f'In {channel}: expected at offset {i} was "{expected}", actual was: "{received_per_channel[channel][i]}"')
 
 
+class TestFrameSizes(TestWebdis):
+    def format(self):
+        return 'json'
+
+    def serialize(self, cmd, *args):
+        return json.dumps([cmd] + list(args))
+
+    def deserialize(self, response):
+        return json.loads(response)
+
+    def test_length_126(self):
+        key = str(uuid.uuid4())
+        value = 'A' * 1024  # this will require 2 bytes to encode the length
+        self.assertEqual(self.exec('SET', key, value), {'SET': [True, 'OK']})
+        self.exec('DEL', key)
+
+    def test_length_127(self):
+        key = str(uuid.uuid4())
+        value = 'A' * (2 ** 18)  # this will require more than 2 bytes to encode the length (actually using 8)
+        self.assertEqual(self.exec('SET', key, value), {'SET': [True, 'OK']})
+        self.exec('DEL', key)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/ws-tests.py
+++ b/tests/ws-tests.py
@@ -97,7 +97,6 @@ class TestRaw(TestWebdis):
         self.assertEqual(get_response, f"${len(value)}\r\n{value}\r\n")
 
 
-@unittest.skipIf(os.getenv('PUBSUB') != '1', "pub-sub test fail due to invalid ordering")
 class TestPubSub(unittest.TestCase):
     def setUp(self):
         self.publisher = connect('json')


### PR DESCRIPTION
As discussed earlier, here are some tests for the WebSocket feature and several changes that I had to make to get them to pass.

I started with the [websockets](https://websockets.readthedocs.io/en/stable/) library as suggested, but it was highly dependent on `asyncio` and had some expectations that I didn't think followed the WS RFCs. For example, it expects the `Sec-WebSocket-Accept` header to come immediately after `Upgrade` and `Connection`, even though I could not find any requirement saying this had to be the case. I still made this change in case some Webdis clients use this library, but for the tests themselves I found it easier to use [websocket-client](https://github.com/websocket-client/websocket-client) instead.

The changes:
1. Change order of headers
2. Make `Origin` and `Sec-WebSocket-Origin` optional, as this is [not required for non-browser clients](https://datatracker.ietf.org/doc/html/rfc6455#section-4.1).
3. I noticed that calling `ws.close()` in the test would take about 3 seconds to return, so called `close()` on the server side when we detect it.
4. These disconnections were logged at a high level so I changed that too.
5. There were a few bugs in the reporting thread added at the last minute to `tests/websocket.c`, these are fixed now.
6. I added a new WS-only test that uses JSON and "raw" commands.

I started adding those to `build.yml` for the GitHub Action, but I didn't know if it would be ok since the feature is disabled by default so I left them out for now.