### PR TITLE
Only call ws_client_free once all scheduled events have triggered

### DIFF
--- a/src/websocket.c
+++ b/src/websocket.c
@@ -113,7 +113,7 @@ ws_client_new(struct http_client *http_client) {
 	return ws;
 }
 
-void
+static void
 ws_client_free(struct ws_client *ws) {
 
 	/* mark WS client as closing to skip the Redis callback */
@@ -558,7 +558,7 @@ ws_frame_and_send_response(struct ws_client *ws, enum ws_frame_type frame_type, 
 	return ws_schedule_write(ws);
 }
 
-static void
+void
 ws_close_if_able(struct ws_client *ws) {
 
 	ws->close_after_events = 1; /* note that we're closing */

--- a/src/websocket.h
+++ b/src/websocket.h
@@ -46,9 +46,6 @@ struct ws_client {
 struct ws_client *
 ws_client_new(struct http_client *http_client);
 
-void
-ws_client_free(struct ws_client *ws);
-
 int
 ws_handshake_reply(struct ws_client *ws);
 
@@ -60,5 +57,8 @@ ws_process_read_data(struct ws_client *ws, unsigned int *out_processed);
 
 int
 ws_frame_and_send_response(struct ws_client *ws, enum ws_frame_type type, const char *p, size_t sz);
+
+void
+ws_close_if_able(struct ws_client *ws);
 
 #endif

--- a/src/worker.c
+++ b/src/worker.c
@@ -79,7 +79,7 @@ worker_can_read(int fd, short event, void *p) {
 				int reply_ret = ws_handshake_reply(c->ws);
 				if(reply_ret < 0) {
 					c->ws->http_client = NULL; /* detach to prevent double free */
-					ws_client_free(c->ws);
+					ws_close_if_able(c->ws);
 					c->broken = 1;
 				} else {
 					unsigned int processed = 0;


### PR DESCRIPTION
Fixes #209. A WS client socket closure could cause Webdis to schedule the send of a closing frame, leading to both `EV_READ` and `EV_WRITE` scheduled events. They would both fail and each lead to a call to `ws_client_free`, causing a double-free and a crash.