### PR TITLE
Fix for premature termination of websocket connection. 

### DIFF
--- a/src/formats/json.c
+++ b/src/formats/json.c
@@ -20,6 +20,8 @@ json_reply(redisAsyncContext *c, void *r, void *privdata) {
 	char *jstr;
 	(void)c;
 
+	if (c->c.flags & REDIS_DISCONNECTING) return; /* closing connection */
+
 	if(cmd == NULL) {
 		/* broken connection */
 		return;

--- a/src/formats/raw.c
+++ b/src/formats/raw.c
@@ -20,6 +20,8 @@ raw_reply(redisAsyncContext *c, void *r, void *privdata) {
 	size_t sz;
 	(void)c;
 
+	if (c->c.flags & REDIS_DISCONNECTING) return; /* closing connection */
+
 	if (reply == NULL) { /* broken Redis link */
 		format_send_error(cmd, 503, "Service Unavailable");
 		return;


### PR DESCRIPTION
If a command waiting for data is used inside the websocket connection (eg XREAD BLOCK 5000 STREAMS ...), then Webdis will crash if the WS connection closes before the response from Redis arrives.
When the WS connection terminates, the data is freed using cmd_free(), which uses a callback from Redis, so the callback function crashes.
The fix adds in the callback functions test that if there is active request to terminate the Redis connection (triggered by redisAsyncDisconnect(ac) during WS closing), the response is no longer processed.