### PR TITLE
Preserve header count when a value is replaced

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -94,6 +94,7 @@ void
 http_response_set_header(struct http_response *r, const char *k, const char *v, header_copy copy) {
 
 	int i, pos = r->header_count;
+	int replaced = 0; /* whether we overwrote a previous value */
 	size_t key_sz = strlen(k);
 	size_t val_sz = strlen(v);
 
@@ -104,6 +105,7 @@ http_response_set_header(struct http_response *r, const char *k, const char *v, 
 				/* free old value before replacing it. */
 				if(r->headers[i].copy & HEADER_COPY_KEY) free(r->headers[i].key);
 				if(r->headers[i].copy & HEADER_COPY_VALUE) free(r->headers[i].val);
+				replaced = 1;
 				break;
 			}
 		}
@@ -116,7 +118,9 @@ http_response_set_header(struct http_response *r, const char *k, const char *v, 
 				sizeof(struct http_header)*(r->headers_array_size + 1));
 		r->headers_array_size++;
 	}
-	r->header_count++;
+	if(!replaced) {
+		r->header_count++;
+	}
 
 	/* copy key if needed */
 	if(copy & HEADER_COPY_KEY) {

--- a/tests/curl-tests.sh
+++ b/tests/curl-tests.sh
@@ -25,4 +25,18 @@ function test_large_put_upload() {
     fi
 }
 
+# GitHub issue #217 (empty header ":" returned for OPTIONS)
+function test_options_headers() {
+    echo -n 'Sending an OPTIONS request... '
+    empty_header_present=$(curl -v -X OPTIONS "http://127.0.0.1:7379/" 2>&1 | grep -cE '^< : ' || true) # || true to avoid false-positive exit code from grep
+
+    if [[ $empty_header_present != 0 ]]; then
+        echo "failed! Found an empty header entry"
+        exit 1
+    else
+        echo 'OK'
+    fi
+}
+
 test_large_put_upload
+test_options_headers


### PR DESCRIPTION
Sorry about this, here is the fix as suggested. I added a test in the curl script since I think this fit better than with the Python tests.