### PR TITLE
Compile in C99 mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CFLAGS ?= -Wall -Wextra -Isrc -Isrc/jansson/src -Isrc/http-parser -MD
 LDFLAGS ?= -levent -pthread
 
 # Pass preprocessor macros to the compile invocation
-CFLAGS += $(CPPFLAGS)
+CFLAGS += $(CPPFLAGS) -std=gnu99
 
 # check for MessagePack
 MSGPACK_LIB=$(shell ls /usr/lib/libmsgpack.so 2>/dev/null)


### PR DESCRIPTION
Fix error when compiling in GCC 4.8.5 on CentOS 7

```
src/websocket.c: In function ‘ws_log_cmd’:
src/websocket.c:247:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
  for(int i = 0; p < eom && i < cmd->count; i++) {
  ^
src/websocket.c:247:2: note: use option -std=c99 or -std=gnu99 to compile your code
make: *** [src/websocket.o] Error 1
```
