### PR TITLE
cmake: initial build/tests for webdis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,143 @@
+#
+# webdis cmake build definition
+#
+cmake_minimum_required(VERSION 3.20)
+
+project(webdis)
+
+# Enforce out-of-source build
+if (${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
+  message(FATAL_ERROR "In-source builds not allowed. Please make a build directory and run CMake from there.")
+endif()
+
+# If CMAKE_BUILD_TYPE is None, set it to Debug
+if (NOT CMAKE_BUILD_TYPE)
+  set (CMAKE_BUILD_TYPE "Debug" CACHE STRING "Debug was set by default" FORCE)
+endif()
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
+
+# User-controlled configuration
+option(WITH_MSGPACK "Add msgpack support" ON)
+option(WITH_OPENSSL "Add OpenSSL support" ON)
+option(WITH_TESTS   "Build tests" ON)
+option(WITH_OWN_HIREDIS "Use local hiredis" OFF)
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic")
+
+include(WebdisProjectDependencies)
+
+# Add those folders as static libraries to re-link them with tests 
+set(B64_SRC
+  src/b64/cencode.c
+  src/b64/cencode.h
+)
+add_library(b64 STATIC ${B64_SRC})
+target_include_directories(b64 PUBLIC src/b64)
+
+set(SHA1_SRC
+  src/sha1/sha1.c
+  src/sha1/sha1.h
+)
+add_library(sha1 STATIC ${SHA1_SRC})
+target_include_directories(sha1 PUBLIC src/sha1)
+
+set(HTTPARSE_SRC
+  src/http-parser/http_parser.c
+  src/http-parser/http_parser.h
+)
+add_library(http_parser STATIC ${HTTPARSE_SRC})
+target_include_directories(http_parser PUBLIC src/http-parser)
+
+set(FORMATS_SRC
+  src/formats/common.c
+  src/formats/common.h
+  src/formats/custom-type.c
+  src/formats/custom-type.h
+  src/formats/json.c
+  src/formats/json.h
+  src/formats/raw.c
+  src/formats/raw.h
+)
+if (msgpack_FOUND)
+  LIST(APPEND FORMATS_SRC
+    src/formats/msgpack.c
+    src/formats/msgpack.h
+  )
+endif()
+
+aux_source_directory(src/jansson/src JANSSON_SRC) # TODO: can be also used from system
+aux_source_directory(src/md5 MD5_SRC)
+aux_source_directory(src WEBDIS_SRC)
+
+if (WITH_OWN_HIREDIS)
+  set(HIREDIS_SRC
+    src/hiredis/hiredis.c
+    src/hiredis/hiredis.h
+    src/hiredis/sds.c
+    src/hiredis/sds.h
+    src/hiredis/net.c
+    src/hiredis/net.h
+    src/hiredis/async.c
+    src/hiredis/async.h
+    src/hiredis/read.c
+    src/hiredis/read.h
+    src/hiredis/dict.c
+    src/hiredis/dict.h
+    src/hiredis/alloc.c
+    src/hiredis/alloc.h
+    src/hiredis/sockcompat.c
+    src/hiredis/sockcompat.h
+  )
+  if (WITH_OPENSSL)
+    list(APPEND HIREDIS_SRC "src/hiredis/ssl.c")
+  endif()
+endif()
+
+add_executable(${PROJECT_NAME} ${JANSSON_SRC} ${FORMATS_SRC} ${MD5_SRC} ${HIREDIS_SRC} ${WEBDIS_SRC})
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE _POSIX_C_SOURCE=200809L)
+target_include_directories(${PROJECT_NAME} PRIVATE src src/jansson/src src/http-parser)
+target_link_libraries(${PROJECT_NAME} PRIVATE http_parser b64 sha1)
+target_link_libraries(${PROJECT_NAME} PRIVATE libevent::libevent Threads::Threads)
+if (NOT WITH_OWN_HIREDIS)
+  target_link_libraries(${PROJECT_NAME} PRIVATE hiredis::hiredis)
+endif()
+if (WITH_OPENSSL)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_SSL=1)
+  target_link_libraries(${PROJECT_NAME} PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
+if (msgpack_FOUND)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE MSGPACK=1)
+  target_link_libraries(${PROJECT_NAME} PRIVATE msgpackc)
+endif()
+
+if (WITH_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()
+
+include(CMakePrintHelpers)
+message(STATUS "=======================================")
+message(STATUS "Configured project: ${PROJECT_NAME}")
+message(STATUS "======= Project variables =============")
+cmake_print_variables(CMAKE_BUILD_TYPE)
+cmake_print_variables(CMAKE_C_COMPILER CMAKE_C_FLAGS)
+cmake_print_variables(WITH_OWN_HIREDIS WITH_MSGPACK WITH_OPENSSL WITH_TESTS)
+cmake_print_properties(TARGETS ${PROJECT_NAME} PROPERTIES COMPILE_DEFINITIONS COMPILE_OPTIONS)
+message(STATUS "======= System discovered variables =============")
+cmake_print_variables(OPENSSL_FOUND OPENSSL_VERSION)
+if (WITH_OWN_HIREDIS)
+  message(STATUS "Using local hiredis sources")
+else()
+  cmake_print_variables(hiredis_FOUND hiredis_hiredis_VERSION)
+endif()
+cmake_print_variables(libevent_FOUND libevent_libevent_VERSION)
+cmake_print_variables(msgpack_FOUND msgpack_VERSION)
+message(STATUS "=======================================")

--- a/cmake/WebdisProjectDependencies.cmake
+++ b/cmake/WebdisProjectDependencies.cmake
@@ -1,0 +1,51 @@
+#
+# webdis dependencies
+#
+#set(CMAKE_FIND_DEBUG_MODE 1)
+
+find_package(Threads REQUIRED)
+if (WITH_OPENSSL)
+  find_package(OpenSSL REQUIRED)
+endif()
+
+# will search packages with pkg-config if no config modules
+find_package(PkgConfig QUIET)
+
+find_package(Libevent QUIET) # todo: check this name from conan...
+if (NOT TARGET libevent::libevent)
+  if (PKG_CONFIG_FOUND)
+    if (WITH_OPENSSL)
+      pkg_check_modules(libevent REQUIRED libevent libevent_openssl libevent_pthreads)
+    else()
+      pkg_check_modules(libevent REQUIRED libevent libevent_pthreads)
+    endif()
+    add_library(libevent::libevent INTERFACE IMPORTED)
+    set_target_properties(libevent::libevent PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${libevent_INCLUDE_DIRS}")
+    set_target_properties(libevent::libevent PROPERTIES INTERFACE_LINK_LIBRARIES "${libevent_LIBRARIES}")
+  else()
+    message(FATAL_ERROR "Unable to find libevent")
+  endif()
+endif()
+
+if (NOT WITH_OWN_HIREDIS)
+find_package(Hiredis QUIET)
+if (NOT TARGET hiredis::hiredis)
+  if (PKG_CONFIG_FOUND)
+    if (WITH_OPENSSL)
+      pkg_check_modules(hiredis REQUIRED hiredis hiredis_ssl)
+    else()
+      pkg_check_modules(hiredis REQUIRED hiredis)
+    endif()
+    add_library(hiredis::hiredis INTERFACE IMPORTED)
+    set_target_properties(hiredis::hiredis PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${hiredis_INCLUDE_DIRS}")
+    set_target_properties(hiredis::hiredis PROPERTIES INTERFACE_LINK_LIBRARIES "${hiredis_LIBRARIES}")
+  else()
+    message(STATUS "Unable to find system hiredis... Useing local sources")
+    set(WITH_OWN_HIREDIS ON CACHE FORCE)
+  endif()
+endif()
+endif() # not WITH_OWN_HIREDIS
+
+if (WITH_MSGPACK)
+  find_package(msgpack QUIET)
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_executable(pubsub pubsub.c)
+target_compile_definitions(pubsub PRIVATE _POSIX_C_SOURCE=200809L)
+target_link_libraries(pubsub PRIVATE b64 sha1 http_parser)
+target_link_libraries(pubsub PRIVATE libevent::libevent Threads::Threads)
+
+# search for Python_EXECUTABLE
+find_package(Python COMPONENTS Interpreter REQUIRED)
+set(TEST_PYTHON_SRC
+  basic.py
+  limits.py
+)
+find_program(PKILL_EXECUTABLE pkill REQUIRED)
+get_filename_component(WEBDIS_LAUNCHER bglaunch.sh ABSOLUTE)
+
+add_test(NAME test_run_webdis_start
+         COMMAND "${WEBDIS_LAUNCHER}" "$<TARGET_FILE:webdis>"
+         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+set_tests_properties(test_run_webdis_start PROPERTIES FIXTURES_SETUP test_run_fixture)
+add_test(NAME test_run_webdis_stop
+         COMMAND "${PKILL_EXECUTABLE}" "webdis")
+set_tests_properties(test_run_webdis_stop PROPERTIES FIXTURES_CLEANUP test_run_fixture)
+
+foreach(_test_file ${TEST_PYTHON_SRC})
+  get_filename_component(_test_name ${_test_file} NAME_WE)
+  get_filename_component(_test_abs_path ${_test_file} ABSOLUTE)
+  add_test(NAME test_${_test_name} COMMAND ${Python_EXECUTABLE} ${_test_abs_path})
+  set_tests_properties(test_${_test_name} PROPERTIES RUN_SERIAL ON)
+  set_tests_properties(test_${_test_name} PROPERTIES FIXTURES_REQUIRED test_run_fixture)
+endforeach()
+
+#add_test(NAME test_pubsub COMMAND "$<TARGET_FILE:pubsub>" "-p" "7379")
+#set_tests_properties(test_pubsub PROPERTIES RUN_SERIAL ON)
+#set_tests_properties(test_pubsub PROPERTIES FIXTURES_REQUIRED test_run_fixture)
+
+add_test(NAME test_bench COMMAND "./tests/bench.sh" WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+set_tests_properties(test_bench PROPERTIES RUN_SERIAL ON)
+set_tests_properties(test_bench PROPERTIES FIXTURES_REQUIRED test_run_fixture)

--- a/tests/bglaunch.sh
+++ b/tests/bglaunch.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+"$@" 2>/dev/null 1>/dev/null 0</dev/null &
+


### PR DESCRIPTION
Added initial build generation with CMake for webdis
What you need for using - cmake, gcc, make or ninja
### How to use 
in webdis repository
`cmake -S. -Bbuild [optional configuration parameters]` to generate webdis build
> where 
> -DCMAKE_BUILD_TYPE=Debug|Release to select build target (Debug by default) 
> -DWITH_OPENSSL=ON|OFF to add/disable OpenSSL support (Enabled by default)
> -DWITH_OWN_HIREDIS=ON|OFF to use own sources or system packaged hiredis library (Disabled, and thus used system library related to #238)
> -DWITH_TESTS=ON|OFF to enable/disable tests (Enabled by default)
> -GNinja - for ninja-build tool usage instead of make (without this option makefile build generated)

`cmake --build build` to build webdis service
`ctest -VV --test-dir build` to run tests

**Optional TODO:**
1. can be added into CI
2. not tested with MacOS (I don't have one)
3. check with conan/vcpkg package managers
4. libjansson also can be excluded from build in favor of system pre-installed (related to #239)
5. pubsub test currently commented out because of #149

Here how it looks
```
╭─> ~/.../webdis ‹dev/cmake-build●› 
╰─$ cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -GNinja
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/lib64/ccache/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/lib64/ccache/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found OpenSSL: /usr/lib64/libcrypto.so (found version "1.1.1l")  
-- Checking for modules 'libevent;libevent_openssl;libevent_pthreads'
--   Found libevent, version 2.1.8-stable
--   Found libevent_openssl, version 2.1.8-stable
--   Found libevent_pthreads, version 2.1.8-stable
-- Checking for modules 'hiredis;hiredis_ssl'
--   Found hiredis, version 1.1.0
--   Found hiredis_ssl, version 1.1.0
-- Found Python: /home/snikulov/bin/python3 (found version "3.11.5") found components: Interpreter 
-- =======================================
-- Configured project: webdis
-- ======= Project variables =============
-- CMAKE_BUILD_TYPE="Release"
-- CMAKE_C_COMPILER="/usr/lib64/ccache/cc" ; CMAKE_C_FLAGS=" -Wall -Wextra -pedantic"
-- WITH_OWN_HIREDIS="OFF" ; WITH_MSGPACK="ON" ; WITH_OPENSSL="ON" ; WITH_TESTS="ON"
-- 
 Properties for TARGET webdis:
   webdis.COMPILE_DEFINITIONS = "_POSIX_C_SOURCE=200809L;HAVE_SSL=1;MSGPACK=1"
   webdis.COMPILE_OPTIONS = <NOTFOUND>

-- ======= System discovered variables =============
-- OPENSSL_FOUND="TRUE" ; OPENSSL_VERSION="1.1.1l"
-- hiredis_FOUND="1" ; hiredis_hiredis_VERSION="1.1.0"
-- libevent_FOUND="1" ; libevent_libevent_VERSION="2.1.8-stable"
-- msgpack_FOUND="1" ; msgpack_VERSION="4.0.0"
-- =======================================
-- Configuring done (0.9s)
-- Generating done (0.0s)
-- Build files have been written to: /home/snikulov/work/github/webdis/build
╭─> ~/.../webdis ‹dev/cmake-build●› 
╰─$ cmake --build build
[9/34] Building C object CMakeFiles/webdis.dir/src/jansson/src/load.c.o
/.../webdis/src/jansson/src/load.c: In function ‘stream_unget’:
/.../webdis/src/jansson/src/load.c:179:49: warning: unused parameter ‘c’ [-Wunused-parameter]
 static void stream_unget(stream_t *stream, char c)
                                                 ^
/.../webdis/src/jansson/src/load.c: In function ‘lex_unget_unsave’:
/...//webdis/src/jansson/src/load.c:211:10: warning: variable ‘d’ set but not used [-Wunused-but-set-variable]
     char d;
          ^
[34/34] Linking C executable webdis
╭─> ~/.../webdis ‹dev/cmake-build●› 
╰─$ ctest --output-on-failure --test-dir build     
Internal ctest changing into directory: /.../webdis/build
Test project /.../webdis/build
    Start 1: test_run_webdis_start
1/5 Test #1: test_run_webdis_start ............   Passed    0.00 sec
    Start 3: test_basic
2/5 Test #3: test_basic .......................   Passed    0.11 sec
    Start 4: test_limits
3/5 Test #4: test_limits ......................   Passed    0.27 sec
    Start 5: test_bench
4/5 Test #5: test_bench .......................   Passed   11.03 sec
    Start 2: test_run_webdis_stop
5/5 Test #2: test_run_webdis_stop .............   Passed    0.02 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =  11.43 sec
╭─> ~/.../webdis ‹dev/cmake-build●› 
```